### PR TITLE
Run deploy-scalene without sudo

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,7 +46,7 @@ jobs:
     # root-owned deployment script, which is intentionally not duplicated here.
     steps:
       - name: Deploy website
-        run: sudo /usr/local/bin/deploy-scalene
+        run: /usr/local/bin/deploy-scalene
 
       - name: Verify production health
         run: |


### PR DESCRIPTION
The runner user triangle-deploy has no passwordless sudo for the whole script, so `sudo /usr/local/bin/deploy-scalene` failed with a password prompt. The script is directly executable by triangle-deploy and already runs its only privileged commands via narrow, pre-authorized sudo rules (systemctl restart/is-active astro-app). Invoke it without sudo.