### PR TITLE
Stop service worker from caching pages and API requests

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -51,6 +51,9 @@ export default defineConfig({
           // build assets -- never HTML pages, which are dynamic and would
           // otherwise be served stale from the cache.
           globPatterns: ["**/*.{js,css,ico,png,svg,webp,woff,woff2}"],
+          // Too large to precache (3.66 MB, over workbox's 2 MB limit);
+          // exclude it so the build doesn't warn/exit non-zero.
+          globIgnores: ["**/images/Rectangle.webp"],
           // MPA/SSR site: do NOT serve a cached shell for page navigations.
           // Navigations must always hit the network so pages are never stale.
           navigateFallback: null,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,7 +45,25 @@ export default defineConfig({
               purpose: "any maskable"
             }
           ]
-        }
+        },
+        workbox: {
+          // This is an SSR site (output: 'server'). Only precache static
+          // build assets -- never HTML pages, which are dynamic and would
+          // otherwise be served stale from the cache.
+          globPatterns: ["**/*.{js,css,ico,png,svg,webp,woff,woff2}"],
+          // MPA/SSR site: do NOT serve a cached shell for page navigations.
+          // Navigations must always hit the network so pages are never stale.
+          navigateFallback: null,
+          // Never let the service worker intercept or fall back API calls
+          // (form submissions, etc.); always send them straight to network.
+          navigateFallbackDenylist: [/^\/api\//],
+          runtimeCaching: [
+            {
+              urlPattern: ({ url }) => url.pathname.startsWith("/api/"),
+              handler: "NetworkOnly",
+            },
+          ],
+        },
       })
     ]
   }


### PR DESCRIPTION
The site is SSR (output: 'server'), but the PWA service worker was precaching HTML and installing a NavigationRoute that served a cached index.html shell for page navigations -- causing stale pages -- and it could intercept form-submission POSTs, producing phantom successes with no email actually sent.

Configure workbox to:
- only precache static build assets, never HTML (globPatterns)
- disable the navigation fallback so navigations always hit the network
- route all /api/* requests NetworkOnly and exclude them from any fallback