### PR TITLE
Random cache fix and ViewTransitions rename

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 import Footer from "../components/Footer.astro";
 import Splash from "../components/Splash.astro";
 import Matomo from "../components/Matomo.astro";
@@ -104,7 +104,7 @@ const websiteJSON = {
     <script type="application/ld+json" set:html={JSON.stringify(websiteJSON)} />
     <!-- Extra head content from child layouts (e.g. article JSON-LD) -->
     <slot name="head" />
-    <ViewTransitions />
+    <ClientRouter />
   </head>
   <body class="w-100 min-h-screen flex flex-col">
     <main class="flex-1">

--- a/src/pages/random.astro
+++ b/src/pages/random.astro
@@ -11,6 +11,13 @@ if (!post) {
   return Astro.rewrite('/404');
 }
 
-return Astro.rewrite("/article/" + post.slug);
+const response = await Astro.rewrite("/article/" + post.slug);
+
+response.headers.set(
+  "Cache-Control",
+  "no-store, no-cache, must-revalidate"
+);
+
+return response;
 
 ---


### PR DESCRIPTION
ViewTransitions has been renamed to ClientRouter.
Add a Cache-Control header to the Astro rewrite response on the random page.