### PR TITLE
fix(scroll): load more articles from a same-origin route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,13 @@ MATOMO=
 # Canonical site origin (e.g. https://www.thetriangle.org).
 SITE_ORIGIN=
 
+# Base URL of the CMS API, including the version prefix (e.g.
+# https://cms.thetriangle.org/v1). Every server-side CMS call goes through
+# this. Vite inlines it at BUILD time from the `.env` file -- it is not read
+# from the process environment when the server starts -- so it must be set
+# before `astro build`, not just before `node dist/server/entry.mjs`. When
+# unset, the code falls back to https://localhost:8080/v1, which silently
+# produces a build that only works on a machine running the CMS locally.
+CMS_API_BASE_URL=
+
 WEATHER_API_KEY=

--- a/src/components/Sections/Scroll.astro
+++ b/src/components/Sections/Scroll.astro
@@ -1,15 +1,14 @@
 ---
     export const prerender = false; // Not needed in 'server' mode
-    const { pageNum, hasMore, sectionSlug, url, apiPath } = Astro.props;
+    const { pageNum, hasMore, sectionSlug, url } = Astro.props;
 ---
 
 <div id="article-loader" style="min-height: 1px;"></div>
-<script is:inline define:vars={{ pageNum, hasMore, sectionSlug, url, apiPath }} data-astro-rerun data-cfasync="false">
+<script is:inline define:vars={{ pageNum, hasMore, sectionSlug, url }} data-astro-rerun data-cfasync="false">
     (() => {
         let isLoading = false;
         let currentPage = 2;
         let localHasMore = hasMore;
-        const limit = 20;
 
         const articleLoader = document.getElementById("article-loader");
         const articlesGrid = document.getElementById("main-left");
@@ -22,16 +21,18 @@
 
             try {
                 const response = await fetch(
-                    apiPath
-                        ? `${apiPath}${sectionSlug}/articles?limit=${limit}&offset=${(currentPage - 1) * limit}`
-                        : `${url}${sectionSlug}?page=${currentPage}`,
+                    `${url}${sectionSlug}?page=${currentPage}`,
                 );
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
                 const data = await response.json();
 
                 if (!data.articles || data.articles.length === 0) {
                     localHasMore = false;
                 } else {
                     currentPage++;
+                    if (data.pagination && data.pagination.hasMore === false) {
+                        localHasMore = false;
+                    }
                     data.articles.forEach((article) => {
                         const articleElement =
                             document.createElement("article");

--- a/src/pages/[sectionSlug].astro
+++ b/src/pages/[sectionSlug].astro
@@ -70,7 +70,7 @@ let hasMore = posts.pagination.hasMore;
                         articles={posts.articles?.slice(13)}
                         style="list"
                     />
-                    <Scroll pageNum={pageNum} hasMore={hasMore} sectionSlug={sectionSlug} apiPath={isSubsectionPage ? "https://localhost:8080/v1/subsections/" : "https://localhost:8080/v1/sections/"} />
+                    <Scroll pageNum={pageNum} hasMore={hasMore} sectionSlug={sectionSlug} url={isSubsectionPage ? "/api/subsections/" : "/api/sections/"} />
                 </div>
                 <div
                     id="main-right"

--- a/src/pages/api/[taxonomy]/[slug].ts
+++ b/src/pages/api/[taxonomy]/[slug].ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from "astro";
+import { getSectionArticles, getSubsectionArticles } from "../../../utils/db.js";
+
+export const prerender = false;
+
+// Infinite scroll runs in the browser, which cannot reach the CMS directly:
+// CMS_API_BASE_URL points at an internal host and the CMS sends no CORS
+// headers. So the page fetches this same-origin route and we make the CMS
+// call server-side, exactly like the first page of results does.
+export const GET: APIRoute = async ({ params, url }) => {
+  const { taxonomy, slug } = params;
+
+  if (taxonomy !== "sections" && taxonomy !== "subsections") {
+    return new Response(JSON.stringify({ error: "Unknown taxonomy" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (!slug) {
+    return new Response(JSON.stringify({ error: "Missing slug" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const page = Math.max(Number(url.searchParams.get("page")) || 1, 1);
+
+  try {
+    const posts =
+      taxonomy === "sections"
+        ? await getSectionArticles(slug, page)
+        : await getSubsectionArticles(slug, page);
+
+    if (!posts) {
+      return new Response(JSON.stringify({ error: "Not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify(posts), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.log(err);
+    const message =
+      (err instanceof Error && err.message) || "Failed to load articles";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};


### PR DESCRIPTION
## The bug

Infinite scroll on section pages is broken on the dev site but fine on the main site.

Section pages passed the CMS URL into the scroll component as a hardcoded `https://localhost:8080`:

```
apiPath={isSubsectionPage ? "https://localhost:8080/v1/subsections/" : "https://localhost:8080/v1/sections/"}
```

That prop feeds an `is:inline` script, so it runs **in the browser**. Every visitor fetched their own localhost, the request threw, and the `catch` set `localHasMore = false` — scrolling stopped silently after the first page. It only ever worked on a dev machine that happened to be running the CMS locally.

Main is unaffected because its article list fetches a same-origin `/proxy/...` path, which is also why the regression didn't surface there.

Swapping in the real CMS hostname would not have fixed it either: the CMS sends no CORS headers and its base URL is an internal host, so a direct browser call can't work by construction. Page 1 already sidesteps this by fetching server-side.

## The fix

- **New `/api/{sections,subsections}/{slug}` route** that calls the same `db.js` helpers used to render page 1, so the CMS call happens server-side. Restricted to the two known taxonomies; anything else 404s. `/api/` is already `NetworkOnly` in the service worker config, so it's the right home for this.
- **`Scroll.astro`**: with both branches page-based again, the `apiPath` special case folds back into the plain `url` form. Also checks `response.ok` — a failing request previously fell through to `.json()` and ended the scroll via the generic catch, which is exactly how the original breakage stayed silent.
- Honors `pagination.hasMore`, which the CMS already returns. Scrolling previously only stopped on an empty page, costing one wasted round trip at the end of every section.

No CMS-side changes were needed; the API and its field names were already correct.

## Also: `CMS_API_BASE_URL` in `.env.example`

It was undocumented. Vite **inlines it at build time** from `.env` — it is *not* read from the process environment at server start — so an unset value silently bakes the `https://localhost:8080/v1` default into the bundle. That applies to every server-side CMS call, not just this one, and it's what made this bug easy to miss locally.

## Verification

Built clean, then ran the built server against a stub CMS:

- `/api/sections/news?page=2` → `offset=20`
- `/api/subsections/foo?page=3` → `offset=40`
- `/api/bogus/foo` → 404

Note this targets `CMS-Testing` rather than `main`, since the code being fixed only exists on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)