### PR TITLE
fix: read has_more from the CMS, and expand puzzle shortcodes

### DIFF
--- a/src/components/Sections/Scroll.astro
+++ b/src/components/Sections/Scroll.astro
@@ -30,7 +30,7 @@
                     localHasMore = false;
                 } else {
                     currentPage++;
-                    if (data.pagination && data.pagination.hasMore === false) {
+                    if (data.pagination && data.pagination.has_more === false) {
                         localHasMore = false;
                     }
                     data.articles.forEach((article) => {

--- a/src/pages/[sectionSlug].astro
+++ b/src/pages/[sectionSlug].astro
@@ -33,7 +33,7 @@ const sectionName = normalizeText(
         : (posts.section.canonical_title ?? posts.section.name)
 );
 
-let hasMore = posts.pagination.hasMore;
+let hasMore = posts.pagination.has_more;
 ---
 
 <BaseLayout title={sectionName + " - The Triangle"}>

--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -12,6 +12,7 @@ import Poll from '../../components/Polls.astro';
 import MostRead from '../../components/MostRead.astro';
 import { getArticle, getArticleComments } from '../../utils/db';
 import { normalizeText } from "../../utils/data";
+import { expandShortcodes } from "../../utils/shortcodes";
 import DonateBlurb from "../../components/DonateBlurb.astro";
 import Section from "../../components/Sections/Section.astro";
 import SubscribeLink from "../../components/SubscribeLink.astro";
@@ -64,7 +65,12 @@ const date_string = months[d.getMonth()] + " " + d.getDate() + ", " + d.getFullY
 
 const authorList = "By " + (authorListLinks.length > 2 ? authorListLinks.join(", ") : authorListLinks.join(""))
 
-const actualArticle = post.content.match("<p[^>]*>(.+?)</p>")
+// Shortcodes have to be expanded before anything inspects or renders the
+// body: the puzzle embed script is only injected when the markup contains
+// pm-embed-div, which is precisely what expansion produces.
+const content = expandShortcodes(post.content);
+
+const actualArticle = content.match("<p[^>]*>(.+?)</p>")
 const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
 
 ---
@@ -81,7 +87,7 @@ const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
                 <div id="print-wrap">
                 <section 
                 id="article" 
-                set:html={authorPrint + post.content
+                set:html={authorPrint + content
                     .replaceAll("https://cms.thetriangle.org/wp-content", "/proxy/wp-content")
                     .replaceAll("https://www.thetriangle.org/wp-content", "/proxy/wp-content")
                     .replace(/srcset="[^"]*"/g, "")
@@ -113,7 +119,7 @@ const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
         </div>}
         {!actualArticle && <section 
                 id="article" 
-                set:html={post.content
+                set:html={content
                     .replaceAll("https://cms.thetriangle.org/wp-content", "/proxy/wp-content")
                     .replaceAll("https://www.thetriangle.org/wp-content", "/proxy/wp-content")
                     .replace(/srcset="[^"]*"/g, "")
@@ -129,7 +135,7 @@ const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
                 }>
                 </section>}
         {!actualArticle && <Comments comments={comments} slug={post.slug ?? article} commentsClosed={commentsClosed} />}
-        {post.content.includes('pm-embed-div') && (
+        {content.includes('pm-embed-div') && (
         <script 
             is:inline 
             id="pm-script" 

--- a/src/pages/api/[taxonomy]/[slug].ts
+++ b/src/pages/api/[taxonomy]/[slug].ts
@@ -1,5 +1,9 @@
 import type { APIRoute } from "astro";
-import { getSectionArticles, getSubsectionArticles } from "../../../utils/db.js";
+import {
+  getAuthorArticles,
+  getSectionArticles,
+  getSubsectionArticles,
+} from "../../../utils/db.js";
 
 export const prerender = false;
 
@@ -7,10 +11,17 @@ export const prerender = false;
 // CMS_API_BASE_URL points at an internal host and the CMS sends no CORS
 // headers. So the page fetches this same-origin route and we make the CMS
 // call server-side, exactly like the first page of results does.
+const loaders = {
+  sections: getSectionArticles,
+  subsections: getSubsectionArticles,
+  authors: getAuthorArticles,
+} as const;
+
 export const GET: APIRoute = async ({ params, url }) => {
   const { taxonomy, slug } = params;
+  const loadArticles = loaders[taxonomy as keyof typeof loaders];
 
-  if (taxonomy !== "sections" && taxonomy !== "subsections") {
+  if (!loadArticles) {
     return new Response(JSON.stringify({ error: "Unknown taxonomy" }), {
       status: 404,
       headers: { "Content-Type": "application/json" },
@@ -26,10 +37,7 @@ export const GET: APIRoute = async ({ params, url }) => {
   const page = Math.max(Number(url.searchParams.get("page")) || 1, 1);
 
   try {
-    const posts =
-      taxonomy === "sections"
-        ? await getSectionArticles(slug, page)
-        : await getSubsectionArticles(slug, page);
+    const posts = await loadArticles(slug, page);
 
     if (!posts) {
       return new Response(JSON.stringify({ error: "Not found" }), {

--- a/src/pages/author/[author].astro
+++ b/src/pages/author/[author].astro
@@ -20,7 +20,7 @@ if (!authorData) {
   return Astro.rewrite('/404');
 }
 
-const hasMore = authorData.pagination.hasMore;
+const hasMore = authorData.pagination.has_more;
 const name = authorData.author?.display_name
 ---
 <BaseLayout title={name + " - The Triangle"}>
@@ -31,7 +31,7 @@ const name = authorData.author?.display_name
     {authorData?.articles?.length > 13 && <div class="grid grid-cols-[1fr] sm:grid-cols-[8fr_4fr] mt-2 xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] mb-[8px] divide-x divide-triangleBlue pt-[5px]">
         <div id="main-left" class="main-side">
             <Section section="" articles={authorData?.articles?.slice(13, 25)} includeName style="list"/>
-            <Scroll pageNum={pageNum} hasMore={hasMore} sectionSlug={authorData?.author?.slug} url="/proxy/wp-json/triangle/v2/author/"/>
+            <Scroll pageNum={pageNum} hasMore={hasMore} sectionSlug={authorData?.author?.slug} url="/api/authors/"/>
         </div>
         <div id="main-right" class="hidden sm:block main-side [&>*:not(:first-child)]:border-t-[1px] [&>*:not(:first-child)]:border-solid [&>*:not(:first-child)]:border-triangleBlue">
             <Poll />

--- a/src/utils/shortcodes.ts
+++ b/src/utils/shortcodes.ts
@@ -1,0 +1,69 @@
+/**
+ * WordPress shortcode expansion.
+ *
+ * Article bodies come out of the CMS as raw `post_content`, which still holds
+ * unexpanded WordPress shortcodes. Under WordPress a plugin expanded these at
+ * render time; nothing does now, so they reach the page as literal
+ * "[puzzleme ...]" text.
+ *
+ * The markup below is what the AmuseLabs plugin actually emitted -- taken from
+ * `content.rendered` for an existing crossword post rather than written from
+ * memory. Notably it drops the shortcode's `basepath`: the embed script
+ * resolves its own CDN, and the working WordPress output carried no
+ * data-basepath at all.
+ */
+
+/** Attributes are single-quoted in practice, but accept double quotes too. */
+function parseAttributes(raw: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const pattern = /([\w-]+)\s*=\s*(?:'([^']*)'|"([^"]*)")/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(raw)) !== null) {
+    attributes[match[1].toLowerCase()] = match[2] ?? match[3] ?? "";
+  }
+  return attributes;
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function puzzlemeEmbed(raw: string): string {
+  const attributes = parseAttributes(raw);
+  const id = attributes.id ?? "";
+  const set = attributes.set ?? "";
+
+  // Without both of these the embed script has nothing to load, so leave the
+  // shortcode visible rather than emitting a silently empty puzzle.
+  if (!id || !set) return `[puzzleme ${raw}]`;
+
+  const puzzleType = attributes.type || "crossword";
+  // Attribution is authored as HTML (it contains a link), so it is inserted
+  // as-is, exactly as WordPress did.
+  const attribution = attributes.attribution ?? "";
+  const attributionDiv = attribution
+    ? `\n            <div class="pm-attribution-div" style="font-family: sans-serif;font-size: 12px;color:#666666;padding-top: 5px;width: 100%">${attribution}</div>`
+    : "";
+
+  return `
+        <div style="position: relative;text-align: center">
+            <div class="pm-embed-div" data-id="${escapeAttribute(id)}" data-set="${escapeAttribute(set)}" data-puzzleType="${escapeAttribute(puzzleType)}" data-height="700px" data-embedparams="embed=wp"></div>${attributionDiv}
+        </div>`;
+}
+
+/**
+ * Expand the shortcodes we support. Anything unrecognised is left untouched,
+ * so an unknown shortcode still shows up as text rather than vanishing.
+ */
+export function expandShortcodes(content: string): string {
+  if (!content || !content.includes("[")) return content;
+
+  return content.replace(/\[puzzleme\s+([^\]]*)\]/gi, (_, raw) =>
+    puzzlemeEmbed(raw),
+  );
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -144,12 +144,18 @@ export interface Subsection {
   canonical_title?: string;
 }
 
+/**
+ * triangle-cms pagination. Note the snake_case: this is the CMS JSON shape,
+ * not the camelCase one the old WordPress endpoints returned. Reading
+ * `hasMore` off this silently yields undefined, which reads as "no more
+ * pages" and stops infinite scroll before it makes a single request.
+ */
 export interface Pagination {
-  currentPage: number;
-  perPage: number;
-  total: number;
-  totalPages: number;
-  hasMore: boolean;
+  page: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+  total_count: number;
 }
 
 export interface SectionArticles {


### PR DESCRIPTION
Two unrelated dev-site breakages.

## Infinite scroll — the actual blocker

Section pages read `pagination.hasMore`, but the CMS returns **`has_more`**. That value was always `undefined`, so `localHasMore` started falsy and `fetchMoreArticles` bailed on its first line:

```js
if (isLoading || !localHasMore) return;
```

Scroll never issued a single request. Confirmed on the deployed dev host, which was serving `const hasMore = undefined;`.

That also means the URL fix in #65 was real but not sufficient — the broken `localhost:8080` fetch was never reached, so correcting it changed nothing observable. Both bugs had to go.

What let this through is the `Pagination` type: it still described the old WordPress shape (`currentPage` / `perPage` / `total` / `totalPages` / `hasMore`), so reading `.hasMore` off a CMS response typechecked cleanly while always being `undefined`. Corrected to the shape the CMS actually sends, which is what surfaced the other read sites.

**Author pages** had the same bug plus a second one: page 2 onwards still pointed at `/proxy/wp-json/triangle/v2/author/` even though page 1 had moved to the CMS. They now use the same-origin route, extended to cover authors alongside sections and subsections.

## Puzzles

Article bodies arrive as raw `post_content` with shortcodes unexpanded, so crosswords rendered as literal `[puzzleme ...]` text — a WordPress plugin used to expand these and nothing does now.

New `expandShortcodes` handles it at render time. The emitted markup isn't invented: it's what the AmuseLabs plugin actually produced, lifted from `content.rendered` for post 69276 and **diffed byte-for-byte** against this implementation's output. Notably it drops the shortcode's `basepath` — the embed script resolves its own CDN, and the working WordPress markup carried no `data-basepath` at all.

Expansion happens before the template tests for `pm-embed-div`, since that test is what injects the embed script. The body is expanded once in the frontmatter and reused, which also de-duplicates the content pipeline across the two render branches. Unknown shortcodes, and `puzzleme` missing an `id` or `set`, are left as text rather than silently dropped.

## Verification

Against a stub serving the real CMS shapes:

- `/news` emits `const hasMore = true;` (previously `undefined`)
- `/api/sections/…`, `/api/subsections/…`, `/api/authors/…` → 200; unknown taxonomy → 404
- Author page: `hasMore = true`, `url = "/api/authors/"`
- Crossword renders `pm-embed-div` with the correct `data-id`, pulls in `puzzleme-embed.js`, and leaks no literal shortcode

`astro build` and `astro check` both clean (0 errors; the 2 warnings are pre-existing unused imports).

Not verified: actual scroll-and-append in a real browser against live data, and the puzzle rendering interactively. The gating bug is proven fixed and the endpoints return real data, but both are worth a manual look once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)