### PR TITLE
fix(polls): hide the poll widget when no poll is on the site

### DIFF
--- a/src/components/Polls.astro
+++ b/src/components/Polls.astro
@@ -1,11 +1,16 @@
 ---
 import { getPollCounts, getPollOptions, getPollTitle } from '../utils/pollStore';
 
+// No options means nothing is on the site -- either no live poll at all, or one
+// with nothing to vote on. Either way the widget renders nothing rather than a
+// "Polls" heading over an empty form and a Vote button that cannot do anything.
 const pollOptions = await getPollOptions();
-const pollOptionCounts = await getPollCounts();
-const pollTitle = await getPollTitle();
+const hasPoll = pollOptions.length > 0;
+const pollOptionCounts = hasPoll ? await getPollCounts() : {};
+const pollTitle = hasPoll ? await getPollTitle() : '';
 const totalVotes = Object.values(pollOptionCounts).reduce((sum, count) => sum + count, 0);
 ---
+{hasPoll && (
 <div class="font-playfair mb-[48px]" data-poll-root>
     <h1 class="font-roboto-slab uppercase font-extrabold mb-2"> Polls </h1>
     <form data-poll-form>
@@ -30,6 +35,7 @@ const totalVotes = Object.values(pollOptionCounts).reduce((sum, count) => sum + 
         See past polls →
     </a>
 </div>
+)}
 
 <script>
   const POLL_CHOICE_KEY = 'triangle-poll-choice';


### PR DESCRIPTION
## What

When no poll is live, `getPollOptions()` returns `[]` and `getPollTitle()` returns `""` — but `Polls.astro` rendered anyway: a **POLLS** heading, an empty `<form>`, an enabled **Vote** button, and the "See past polls →" link. That block is imported by the homepage, section pages, article pages and author pages, so an empty poll shows up site-wide.

## Change

- Gate the whole widget on `pollOptions.length > 0`. This also covers a published poll with no options, which can't be voted on either.
- Skip the `getPollCounts()` / `getPollTitle()` requests when there are no options; the options call already answers the question.

The hoisted `<script>` needed no change — it is already `pollRoot?`-guarded and no-ops when the block is absent.

## Judgment calls worth a second opinion

- A poll with a question but zero options is treated as "no poll".
- The "See past polls →" link disappears with the widget, so `/pollsarchive` is only linked from a live poll. Easy to pull out of the conditional if we'd rather it always show.

## Testing

`npx astro check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)