### PR TITLE
Restore the spaces compressHTML eats around inline links

### DIFF
--- a/src/components/DonateBlurb.astro
+++ b/src/components/DonateBlurb.astro
@@ -1,9 +1,11 @@
 ---
 ---
 <div class="bg-triangleBlue text-white font-roboto-slab max-w-[700px] mx-auto p-5 flex flex-wrap donate">
-    <p>For 100 years, The Triangle has operated as a financially and editorially independent student newspaper. 
-        In order to continue this legacy, The Triangle relies on the generosity of our alumni, family, and friends. Please 
-        <a class="underline font-bold" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154">consider donating to The Triangle</a> 
+    <!-- The {" "} around the link are load-bearing: compressHTML strips the
+         whitespace at these line breaks, running the words together. -->
+    <p>For 100 years, The Triangle has operated as a financially and editorially independent student newspaper.
+        In order to continue this legacy, The Triangle relies on the generosity of our alumni, family, and friends. Please{" "}
+        <a class="underline font-bold" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154">consider donating to The Triangle</a>{" "}
         in order to secure the future of student-journalism at Drexel.</p>
     <a class="inline-block bg-triangleSecondary uppercase p-2 mt-[8px] mx-auto" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154"> Donate </a>
 </div>

--- a/src/pages/one-hundred.astro
+++ b/src/pages/one-hundred.astro
@@ -30,15 +30,15 @@ import '../styles/global.css';
                 <br/><br/>
                 In honor of this milestone, The Triangle has made copies of the 100th Anniversary print newspaper available for purchase. All proceeds 
                 of these sales will be directed to The Triangle's endowment, with each purchase ensuring that The Triangle runs in perpetuity. Papers 
-                will be mailed out on a weekly basis and delivered to the address of the purchaser. Buy a copy 
+                will be mailed out on a weekly basis and delivered to the address of the purchaser. Buy a copy{" "}
                 <a target="_blank" rel="noopener noreferrer" href="https://secure.touchnet.com/C20688_ustores/web/product_detail.jsp?PRODUCTID=5169" class="text-triangleBlue font-bold underline">here</a>.
             </p>
             <img src="/proxy/wp-content/uploads/2026/03/front-cover-with-words-scaled.png" class="h-[280px] aspect-1 border-[1px] border-triangleBlue"/>
         </div>
         <div class="bg-triangleBlue text-white font-roboto-slab p-5 flex flex-wrap mt-[16px]">
-        <p>For 100 years, The Triangle has operated as a financially and editorially independent student newspaper. 
-            In order to continue this legacy, The Triangle relies on the generosity of our alumni, family, and friends. Please 
-            <a class="underline font-bold" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154">consider donating to The Triangle</a> 
+        <p>For 100 years, The Triangle has operated as a financially and editorially independent student newspaper.
+            In order to continue this legacy, The Triangle relies on the generosity of our alumni, family, and friends. Please{" "}
+            <a class="underline font-bold" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154">consider donating to The Triangle</a>{" "}
             in order to secure the future of student-journalism at Drexel.</p>
         <a class="inline-block bg-triangleSecondary uppercase p-2 mt-[8px] mx-auto" target="_blank" rel="noopener noreferrer" href="https://alumni.drexel.edu/s/1683/form/16/form.aspx?sid=1683&gid=2&pgid=4355&content_id=4154"> Donate </a>
     </div>
@@ -58,7 +58,7 @@ import '../styles/global.css';
         </div>
         <h2 class="font-playfair text-[28px] mb-[16px] mt-[16px]"> Library Exhibit </h2>
         <div>
-            To mark this important milestone in the paper's history, the Drexel University Archives is excited to announce a 
+            To mark this important milestone in the paper's history, the Drexel University Archives is excited to announce a{" "}
             <a href="https://libcal.library.drexel.edu/event/16291867" class="text-triangleBlue font-bold underline">two-part exhibit</a>,  "Celebrating a Century of The Triangle: 1926 to 2026."
             <br/><br/>
             Part One of the exhibit features historical issues of The Triangle from the last 100 years, which are now on display outside the University Archives' 


### PR DESCRIPTION
The donate blurb renders on production as **"Pleaseconsider donating to The Trianglein order to secure ..."** — the spaces around the donation link are gone.

## Cause

Astro's `compressHTML` (on by default for builds, off in `astro dev`) strips the whitespace at a line break between a text node and an inline element. The source had the link on its own line, so `Please\n<a>…</a>\nin order` collapsed with no separator. It only reproduces in a production build, which is why it survived local review.

## Fix

Explicit `{" "}` at those boundaries in `DonateBlurb.astro`, plus a comment noting the spaces are load-bearing. While scanning for the same pattern I found two more instances on `/one-hundred` and fixed them too:

- "Buy a copyhere."
- "announce atwo-part exhibit"

## Verification

`npx astro build`, then inspected the output:

- prerendered `/one-hundred` HTML: `Please consider`, `Buy a copy <a`, `announce a <a`
- SSR article chunk: emits `${" "}` between `Please` and the link, which renders as a space at request time

🤖 Generated with [Claude Code](https://claude.com/claude-code)