### PR TITLE
Stop puzzle posts from showing their thumbnail above the embed

### DIFF
--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -101,11 +101,16 @@ const articleHtml = stripDimensions(proxyWpContent(content));
 const actualArticle = /<(p|div|blockquote|h[1-6])(\s[^>]*)?>\s*[^<\s][\s\S]*?<\/\1>/i.test(content);
 const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
 
+// Puzzle posts set a screenshot of the puzzle as their featured image so they
+// have a thumbnail in section lists and social cards, but on the article page
+// the playable embed sits right below it -- the still is pure duplication.
+const hasPuzzleEmbed = content.includes("pm-embed-div");
+
 // Legacy WordPress bodies carry their lead image inline as a <figure>, so only
 // posts without any inline image need the featured image rendered for them --
 // otherwise every imported article would show it twice.
 const featuredImage =
-  post.featured_image && !/<img\b/i.test(content)
+  post.featured_image && !/<img\b/i.test(content) && !hasPuzzleEmbed
     ? proxyWpContent(post.featured_image)
     : undefined;
 
@@ -144,7 +149,7 @@ const featuredImage =
                 </section>}
         {!actualArticle && <Comments comments={comments} slug={post.slug ?? article} commentsClosed={commentsClosed} />}
         {!actualArticle && <DonateBlurb/>}
-        {content.includes('pm-embed-div') && (
+        {hasPuzzleEmbed && (
         <script 
             is:inline 
             id="pm-script" 


### PR DESCRIPTION
## Problem

Crossword posts render a screenshot of the puzzle immediately above the playable AmuseLabs embed — the same grid twice. Visible live on [/article/the-finale](https://www.thetriangle.org/article/the-finale), which serves:

```html
<section id="article"><figure><img src=".../Screenshot-2026-06-03-at-21.32.21.png" alt="The Finale"></figure>
...
<div class="pm-embed-div" data-id="791ebe50" ...>
```

Puzzle posts set that screenshot as their featured image so they have a thumbnail in section lists and social cards. Their body is nothing but the `[puzzleme ...]` shortcode, so the "body has no inline `<img>`, so render the featured image" rule in `[article].astro` — which exists for legacy WordPress bodies that carry their lead image inline — fired on them too.

## Fix

Skip the in-body featured image when the expanded body contains a puzzle embed, and reuse that flag for the embed-script condition further down instead of recomputing the same string check.

The OG/schema image in `ArticleLayout` is untouched, so social cards and section thumbnails keep the screenshot.

`astro check`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)