### PR TITLE
Fix article paragraphs losing their font when an ad is injected into them

### DIFF
--- a/src/components/Classified.astro
+++ b/src/components/Classified.astro
@@ -6,5 +6,5 @@
 <article class="break-all mb-[8px] md:mb-[4px] [.grid_&:not(:first-child)]:pt-[8px] pb-[8px] cursor-default [&:not(:last-child)]:border-b-[1px] border-solid border-triangleGray-400">
     {label&& <h3 class="font-roboto-slab uppercase font-extrabold text-triangleBlue text-[10px] font-700"> {label} </h3>}
     <div class="font-roboto-slab text-[12px] mb-[8px]">{contact} | <a href={"mailto: " + email}>{email}</a></div>
-    <div class="font-crimson text-[16px]">{normalizeText(message)}</div>
+    <div class="text-[16px]">{normalizeText(message)}</div>
 </article>

--- a/src/components/DevStory.astro
+++ b/src/components/DevStory.astro
@@ -7,5 +7,5 @@
     {labels && labels[0] && <h3 class="font-roboto-slab uppercase font-extrabold text-triangleDanger text-[10px] font-700"> {labels[0].name} </h3>}
     {link && <a href={"https://www.thetriangle.org/article/" + link}><h2 class="font-playfair text-[20px] leading-tight"> {title} </h2></a>}
     {!link && <h2 class="font-playfair text-[20px] leading-tight"> {title} </h2>}
-    {excerpt && <div class="font-crimson text-[16px]">{normalizeText(excerpt)}</div>}
+    {excerpt && <div class="text-[16px]">{normalizeText(excerpt)}</div>}
 </article>

--- a/src/components/PhotoArticle.astro
+++ b/src/components/PhotoArticle.astro
@@ -43,5 +43,5 @@ const imgClass = row
     <h2 class="font-playfair text-[20px] leading-tight hover:underline">{normalizeText(title)}</h2>
   </a>
   <div id="byline" class="font-playfair text-[12px]" set:html={byline} />
-  {excerpt && <div set:html={normalizeText(excerpt)} class="font-crimson text-[16px]" />}
+  {excerpt && <div set:html={normalizeText(excerpt)} class="text-[16px]" />}
 </article>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,7 +7,7 @@ import '../styles/global.css';
 <BaseLayout title="About - The Triangle">
     <Header/>
     <img src="/images/staff.jpg" class="w-[100%] aspect-[2.75] object-cover object-top mt-[-24px] mb-[24px]"/>
-    <section class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-crimson">
+    <section class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto]">
         <h1 class="font-playfair text-[42px] mb-[16px]"> About Us </h1>
         <div>
             The Triangle is Drexel University's editorially and financially independent student newspaper. 

--- a/src/pages/classifieds.astro
+++ b/src/pages/classifieds.astro
@@ -34,7 +34,7 @@ const classifieds = await getClassifieds();
         Classifieds
     </h1>
     <div
-        class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-crimson text-[16px] my-[16px]"
+        class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] text-[16px] my-[16px]"
     >
         Looking for a sublet, research participants, or free advertising for
         your upcoming Drexel event? Submit a classified!

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -15,7 +15,7 @@ import '../styles/global.css';
         <a class="hover:border-triangleBlue hover:border-b-[1px] pb-[4px] px-[4px]" href="/tipline">Tipline</a>
         <a class="hover:border-triangleBlue hover:border-b-[1px] pb-[4px] px-[4px]" href="/guest">Guest Post</a>
     </div>
-    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-crimson text-[16px] my-[16px]">
+    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] text-[16px] my-[16px]">
         Interested in advertising with The Triangle? Check out our <a href="/proxy/wp-content/uploads/2026/01/The-Triangle-Media-Kit.pdf" class="underline hover:text-triangleBlue">media kit</a>!<br/>
         Have a business inquiry, content request or update? We'd love to hear from you! Please use our contact form to reach out, and we'll 
         get back to you as soon as possible.

--- a/src/pages/guest.astro
+++ b/src/pages/guest.astro
@@ -17,7 +17,7 @@ import '../styles/global.css';
     </div>
 
     <h2 class="font-playfair text-[28px] mb-[16px] mt-[16px] xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto]"> Content Guidelines </h2>
-    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-crimson">
+    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto]">
         The Triangle is the student newspaper of Drexel University. As such, content should focus on events and 
         topics relevant to the university and its students. Content outside of the scope of the university or the 
         city of Philadelphia should predominantly feature a college student perspective or Drexel-related angle.
@@ -27,7 +27,7 @@ import '../styles/global.css';
         received.</b> This includes but is not limited to quotes and information obtained “off-the-record” or on hold-for-release. 
         The Triangle may refuse to publish content that contains any of the following:
         <br/><br/>
-        <ul class="list-disc xl:max-w-[1100px] lg:max-w-[800px] max-w-[90%] mx-[auto] font-crimson">
+        <ul class="list-disc xl:max-w-[1100px] lg:max-w-[800px] max-w-[90%] mx-[auto]">
             <li>vulgar language outside of a direct quote;</li>
             <li>explicit sexual details and sexual content in general unless the material is purely factual for the purposes of education;</li>
             <li>hate speech and discriminatory language outside the context of a direct quote;</li>
@@ -50,10 +50,10 @@ import '../styles/global.css';
     </div>
 
     <h2 class="font-playfair text-[28px] mb-[16px] mt-[16px] xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto]"> Content Removal </h2>
-    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] pb-[32px] border-triangleGray border-b-[1px] font-crimson">
+    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] pb-[32px] border-triangleGray border-b-[1px]">
         The Triangle Editorial Board may decide to remove published content if and only if at least one of the following applies: 
         <br/><br/>
-        <ul class="list-disc xl:max-w-[1100px] lg:max-w-[800px] max-w-[90%] mx-[auto] font-crimson">
+        <ul class="list-disc xl:max-w-[1100px] lg:max-w-[800px] max-w-[90%] mx-[auto]">
             <li>The article contains factually inaccurate information</li>
             <li>The article no longer meets the editorial standards outlined by this document</li>
             <li>The article presents a clear and present danger to the safety of any individual named in the article</li>

--- a/src/pages/subscribe.astro
+++ b/src/pages/subscribe.astro
@@ -15,7 +15,7 @@ import "../styles/global.css";
     Subscribe to our Newsletter
   </h1>
   <div
-    class="font-crimson text-[16px] my-[16px]"
+    class="text-[16px] my-[16px]"
   >
     Get The Triangle right to your inbox!
   </div>

--- a/src/pages/tipline.astro
+++ b/src/pages/tipline.astro
@@ -15,7 +15,7 @@ import '../styles/global.css';
         <a class="border-triangleBlue border-b-[1px] pb-[4px] px-[4px]" href="/tipline">Tipline</a>
         <a class="hover:border-triangleBlue hover:border-b-[1px] pb-[4px] px-[4px]" href="/guest">Guest Post</a>
     </div>
-    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-crimson text-[16px] my-[16px]">
+    <div class="xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] text-[16px] my-[16px]">
         Have some interesting news, a breaking story, or an upcoming event you want us to cover? <br/>
         Are you a member of the Drexel Community and want to write the article yourself and submit it as a guest post? Submit it <a href="/guest" class="underline hover:text-triangleBlue">here</a>.
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,17 +141,41 @@ body {
 }
 
 /*
+ * The body typeface lives on the container, not on the per-block rule below.
+ * That rule has to sniff each block's contents to tell prose from layout
+ * wrappers, and a block can stop matching for reasons outside our control --
+ * flytedesk injects its in-content ad units *inside* a paragraph, which used to
+ * drop that paragraph out of the rule and let it inherit body's generic serif
+ * (Times on iOS). Anchoring the font here means a mis-sniffed block can lose
+ * its measure but never its face.
+ */
+#article {
+  @apply font-roboto-slab;
+}
+
+/*
  * Bodies reach us in two shapes. Legacy WordPress content uses <p> per
  * paragraph; anything authored or re-saved in the Delta CMS comes out of Trix,
  * which wraps every block in a plain <div> instead. Both have to read the same.
  *
- * The :not(:has(...)) guard keeps this off wrapper divs that exist for layout
- * rather than prose -- most importantly the puzzle embed, which would otherwise
- * be squeezed into the 700px prose column.
+ * The :not(...) guard keeps this off wrapper divs that exist for layout rather
+ * than prose -- most importantly the puzzle embed, which would otherwise be
+ * squeezed into the 700px prose column. It carries .article-embed to say so
+ * outright; the :has() clauses are the fallback for legacy WordPress bodies,
+ * which wrap embeds in bare divs we cannot go back and annotate.
+ *
+ * Ad containers are subtracted from those clauses. They are injected into real
+ * paragraphs after load, and once an ad fills they sprout an <iframe> too, so
+ * without this a paragraph is disqualified by whichever clause the ad trips.
  */
 #article p,
-#article > div:not(:has(div, figure, iframe, table, script)) {
-  @apply font-roboto-slab my-[16px] text-[16px] max-w-[700px] mx-[auto];
+#article > div:not(
+    .article-embed,
+    :has(figure, table, script),
+    :has(div:not(.flytead, .flytead *)),
+    :has(iframe:not(.flytead *))
+  ) {
+  @apply my-[16px] text-[16px] max-w-[700px] mx-[auto];
 }
 
 /*

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,8 +13,16 @@
   --color-gray: #E5E7EB;
 }
 
+/*
+ * This said "Crimson Text", serif -- but nothing ever loaded Crimson Text (the
+ * @font-face imports above cover Roboto Slab, Playfair Display and Libre
+ * Franklin only), so every page has always rendered the generic serif behind
+ * it. Naming the family we actually get keeps the stylesheet honest; if we ever
+ * want Crimson Text for real, it needs an @import first. The matching
+ * `font-crimson` Tailwind token was dropped for the same reason.
+ */
 body {
-  font-family: "Crimson Text", serif;
+  font-family: serif;
   font-size: 18px;
   background-color: white;
 }

--- a/src/utils/shortcodes.ts
+++ b/src/utils/shortcodes.ts
@@ -50,8 +50,11 @@ function puzzlemeEmbed(raw: string): string {
     ? `\n            <div class="pm-attribution-div" style="font-family: sans-serif;font-size: 12px;color:#666666;padding-top: 5px;width: 100%">${attribution}</div>`
     : "";
 
+  // .article-embed opts this wrapper out of the prose column in global.css.
+  // The stylesheet can otherwise only infer "layout, not prose" from a block's
+  // contents, which is a guess a third-party script can invalidate.
   return `
-        <div style="position: relative;text-align: center">
+        <div class="article-embed" style="position: relative;text-align: center">
             <div class="pm-embed-div" data-id="${escapeAttribute(id)}" data-set="${escapeAttribute(set)}" data-puzzleType="${escapeAttribute(puzzleType)}" data-height="700px" data-embedparams="embed=wp"></div>${attributionDiv}
         </div>`;
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -9,7 +9,8 @@ export default {
 	theme: {
 		extend: {
 			fontFamily: {
-				'crimson': ['Crimson Text'],
+				// No 'crimson' token: Crimson Text was never loaded, so it only ever
+				// resolved to the body serif its users already inherit.
 				'roboto-slab': ["Roboto Slab", 'serif'],
 				'playfair': ['Playfair Display'],
 				'libre': ['Libre Franklin']


### PR DESCRIPTION
A reader reported a paragraph of [Flip flops are the worst footwear](https://www.thetriangle.org/article/flip-flops-are-the-worst-footwear) rendering in the wrong font on an iPhone. The paragraph is fine — the ad script is the cause.

## The bug

Body prose is styled by a rule that has to tell prose blocks from layout wrappers, and it did that by sniffing each block's contents:

```css
#article > div:not(:has(div, figure, iframe, table, script))
```

Trix wraps every paragraph in a bare `<div>`, so that guard was the only way to keep the puzzle embed out of the 700px prose column. But **flytedesk injects its in-content ad units *inside* a paragraph**. The injected `<div>` makes the paragraph match `:has(div)`, so it drops out of the rule, loses `font-family`, and falls back to the body serif — Times on iOS.

Mobile only, because that's where the in-content units are injected; on desktop the ads go in the right rail.

The same paragraphs also silently lost `max-width: 700px` and their margins. Invisible on a 390px phone where the column is already narrower, but the same broken match.

## Evidence

Rendering the live page in WebKit at iPhone size, the two paragraphs with injected ad units are exactly the two that fall back:

```
idx4  matches=False  "Crimson Text", serif   kids=[DIV.flytead …, A, A]   "A major harm of flip flops…"
idx5  matches=False  "Crimson Text", serif   kids=[DIV.flytead …]         "Not only does this lead to…"
idx9  matches=True   "Roboto Slab", serif    kids=[A]                     "Flip flops are cheaply made…"
```

`idx9` also contains links and is fine — links aren't the trigger, the injected div is. Removing the ad div at runtime flips it straight back.

## The fix

Two changes, because content-sniffing will never be fully reliable against a third-party script:

1. **The typeface moves onto `#article` itself.** A mis-sniffed block can now lose its measure but never its face.
2. **The guard subtracts ad containers.** The `iframe` clause matters as much as the `div` one — the units in the wild are currently collapsed, and a *filled* ad sprouts an `<iframe>` that would trip the other clause. Fixing only the `div` case would leave the bug live on filled ads.

The puzzle wrapper now carries `.article-embed` to say outright that it isn't prose, instead of relying on the stylesheet inferring that from its contents. The `:has()` clauses stay as the fallback for legacy WordPress bodies, which wrap embeds in bare divs we can't retroactively annotate.

## Second commit: the Crimson Text no-op

Tracking the fallback down surfaced that `"Crimson Text"` was declared on `body` and behind a `font-crimson` token used in 13 places, but **nothing has ever loaded it** — the `@font-face` imports cover Roboto Slab, Playfair Display and Libre Franklin only. It's a rename, not a redesign: `body` now names the serif it actually gets, and the dead token and class usages are removed.

⚠️ **Worth a look from whoever owns the site's typography:** someone once wanted Crimson Text on the About/Contact/Guest/Tipline copy and article excerpts, and it silently never shipped. If that intent is still live, the fix is the *opposite* of this commit — add the `@import` and keep the token. I made it visually neutral rather than guessing.

## Verification

- **Live page, real ad script, WebKit at iPhone size**, new stylesheet swapped in — the two ad-bearing paragraphs now hold both properties:
  ```
  idx 2 AD  "Roboto Slab", serif  max-w=700px  A major harm of flip flops is that the
  idx 3 AD  "Roboto Slab", serif  max-w=700px  Not only does this lead to dirtier fee
  ```
- **Selector case matrix**, covering plain prose, prose with links, prose with a collapsed ad, prose with a *filled* ad, the puzzle embed, legacy wrappers containing iframe/table/figure/nested-div, and legacy WP `<p>` — **10/10 in WebKit and 10/10 in Chromium.**
- **Crimson removal A/B** — for every `.font-crimson` element on `/about`, `/contact`, `/tipline`, `/guest`, `/subscribe`, `/classifieds` and `/`, compared the fonts Chromium *actually rasterizes* before and after: **11 elements, 0 rendering differences.**
- `astro check` 0 errors, `eslint` clean, build succeeds.

There's no test runner in this repo, so the case matrix isn't committed.

## Not addressed

The same reader also noted the missing photo credit — the featured image renders no `figcaption`. Separate issue, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
