### PR TITLE
Read the featured image's alt text from the article

### DIFF
--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -114,6 +114,13 @@ const featuredImage =
     ? proxyWpContent(post.featured_image)
     : undefined;
 
+// The description the editor wrote for this image on this article. No fallback
+// to the headline: it sits directly above the image, so announcing it again as
+// the alt tells a screen-reader user nothing they haven't just heard. An empty
+// alt leaves the gap visible to an audit instead of hiding it behind a
+// duplicate.
+const featuredImageAlt = normalizeText(post.featured_image_alt ?? "");
+
 ---
 <ArticleLayout title={normalizeText(post.title) + " - The Triangle"} article={post}>
     <Header/>
@@ -127,7 +134,7 @@ const featuredImage =
             <div id="main-left" class="main-side">
                 <div id="print-wrap">
                 <section id="article">
-                    {featuredImage && <figure><img src={featuredImage} alt={normalizeText(post.title)}/></figure>}
+                    {featuredImage && <figure><img src={featuredImage} alt={featuredImageAlt}/></figure>}
                     <Fragment set:html={authorPrint + articleHtml} />
                 </section>
                 </div>
@@ -144,7 +151,7 @@ const featuredImage =
             </div>
         </div>}
         {!actualArticle && <section id="article">
-                    {featuredImage && <figure><img src={featuredImage} alt={normalizeText(post.title)}/></figure>}
+                    {featuredImage && <figure><img src={featuredImage} alt={featuredImageAlt}/></figure>}
                     <Fragment set:html={articleHtml} />
                 </section>}
         {!actualArticle && <Comments comments={comments} slug={post.slug ?? article} commentsClosed={commentsClosed} />}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -72,6 +72,12 @@ export interface Article {
   authors: Author[];
   content: string;
   featured_image: string;
+  /**
+   * triangle-cms: the editor's description of `featured_image`, written on the
+   * article rather than on the library record. Absent on WordPress-era
+   * articles, which never had anywhere to put one.
+   */
+  featured_image_alt?: string;
   categories_list: Category[];
   seo: Seo;
   related: RelatedArticle[];


### PR DESCRIPTION
The public half of [triangle-cms#197](https://github.com/DrexelTriangle/triangle-cms/pull/197), which gives the CMS a per-article description for the featured image and serves it as `featured_image_alt`. Nothing renders it until this lands.

## What was wrong

The featured image's alt was `normalizeText(post.title)` — the headline, on an image that sits directly under an `<h1>` holding that same headline. A screen reader announced the headline, then announced the image "described" as the headline again. Nothing about the picture, and no way for an audit to spot the omission, because every article had an alt.

## What this does

Renders `post.featured_image_alt` at both call sites (the prose layout and the image-only one comics and photo posts get).

**No fallback.** An empty alt is what the CMS asks for when the field is blank — its own comment on the field says an alt that repeats the adjacent headline "tells a screen-reader user nothing new," and leaving it empty keeps the gap visible to an audit instead of papering over it. WordPress-era articles have no value here, so the type is optional.

## Not in scope, but worth knowing

`ArticleLayout.astro` hardcodes `<meta name="robots" content="index, follow">` and never reads `seo.noindex`, while the CMS sitemap already excludes noindex articles. That is the sitemap-says-one-thing-page-says-another contradiction search engines report as an error. `BaseLayout` already accepts a `noindex` prop; `ArticleLayout` just doesn't pass one. Separate PR.

## Testing

`astro check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)