### PR TITLE
Describe the lead image on imported articles too

### DIFF
--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -89,7 +89,63 @@ const stripDimensions = (html: string) =>
       return cleaned ? `style="${cleaned}"` : "";
     });
 
-const articleHtml = stripDimensions(proxyWpContent(content));
+// The description the editor wrote for this image on this article. No fallback
+// to the headline: it sits directly above the image, so announcing it again as
+// the alt tells a screen-reader user nothing they haven't just heard. An empty
+// alt leaves the gap visible to an audit instead of hiding it behind a
+// duplicate.
+const featuredImageAlt = normalizeText(post.featured_image_alt ?? "");
+
+// A media file identified by its upload, with WordPress's size suffix removed.
+// The body's copy of the lead image is a resized variant of the same upload the
+// CMS holds as the featured image -- P1180110-1-1024x770.jpg against
+// P1180110-1.jpg -- so the two only line up once the -WxH is gone.
+const mediaKey = (url: string): string =>
+  (url.split(/[?#]/)[0].split("/").pop() ?? "")
+    .replace(/\.(jpe?g|png|gif|webp|avif)$/i, "")
+    .replace(/-\d+x\d+$/, "")
+    .toLowerCase();
+
+const escapeAttribute = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+// Put the editor's description on the tag readers actually reach.
+//
+// Imported articles keep their lead image inline in the body, so the featured
+// image is never rendered for them (see featuredImage below) and the alt the
+// CMS holds for it would go nowhere. WordPress exported those <img>s with
+// alt="", which is most of the archive: of the 40 most recently published
+// articles, 37 lead with the featured image inline and 36 of those have no
+// description on it.
+//
+// Only when it is demonstrably the same photo, and only when there is nothing
+// there to overwrite -- an alt an author wrote is better than one written for a
+// different context. First image only: describing the lead photo says nothing
+// about the third one down the page.
+const describeLeadImage = (html: string): string => {
+  const featuredKey = post.featured_image ? mediaKey(post.featured_image) : "";
+  if (!featuredImageAlt || !featuredKey) return html;
+
+  // Non-global on purpose: only the first <img> in the body is a candidate.
+  return html.replace(/<img\b[^>]*>/i, (tag) => {
+    const src = /\ssrc="([^"]*)"/i.exec(tag)?.[1];
+    if (!src || mediaKey(src) !== featuredKey) return tag;
+
+    const alt = /\salt="([^"]*)"/i.exec(tag);
+    if (alt?.[1].trim()) return tag;
+
+    const described = `alt="${escapeAttribute(featuredImageAlt)}"`;
+    return alt
+      ? tag.replace(/\salt="[^"]*"/i, ` ${described}`)
+      : tag.replace(/<img\b/i, `<img ${described}`);
+  });
+};
+
+const articleHtml = describeLeadImage(stripDimensions(proxyWpContent(content)));
 
 // "Does this body have prose?" -- comics and other image-only posts don't, and
 // they get the single-column treatment. This used to look for <p> alone, which
@@ -113,13 +169,6 @@ const featuredImage =
   post.featured_image && !/<img\b/i.test(content) && !hasPuzzleEmbed
     ? proxyWpContent(post.featured_image)
     : undefined;
-
-// The description the editor wrote for this image on this article. No fallback
-// to the headline: it sits directly above the image, so announcing it again as
-// the alt tells a screen-reader user nothing they haven't just heard. An empty
-// alt leaves the gap visible to an audit instead of hiding it behind a
-// duplicate.
-const featuredImageAlt = normalizeText(post.featured_image_alt ?? "");
 
 ---
 <ArticleLayout title={normalizeText(post.title) + " - The Triangle"} article={post}>


### PR DESCRIPTION
Follow-up to #71. The featured image's alt text works — but only on articles written in the CMS. On an imported article it has nowhere to go.

## Why

Imported bodies carry their lead image inline as a `<figure>`, so `[article].astro` deliberately does not render the featured image for them (it would show the same photo twice). That means the inline `<img>` is the tag a screen reader actually reaches, and WordPress exported those with `alt=""`.

This is most of the archive, not an edge case. Of the 40 most recently published articles:

- **37** lead with the featured image inline
- **36** of those carry no description on that tag

So an editor could write a description in the CMS and change nothing a reader hears.

## What this does

Moves the description onto the inline tag, under two conditions:

1. **Demonstrably the same photo.** The body's copy is a WordPress size variant of the same upload — `P1180110-1-1024x770.jpg` against `P1180110-1.jpg` — so the comparison is the upload's basename with the `-WxH` suffix and extension stripped.
2. **Nothing there to overwrite.** An alt an author wrote for this spot beats one written for the featured slot.

First image only: describing the lead photo says nothing about the third photo down the page.

## Testing

Rendered against a stub API, all seven shapes:

| case | result |
|---|---|
| `alt=""`, same upload | description filled in |
| no `alt` attribute at all | description filled in |
| author's own alt present | left untouched |
| lead image is a different photo | left untouched |
| no description in the CMS | left untouched |
| featured photo appears *second* | left untouched |
| Trix body, no inline image | featured image still renders with its alt |

Ampersands and quotes in a description are escaped into the attribute. `astro check`: 0 errors; eslint clean.

Note this is a no-op on production today — every article's `featured_image_alt` is still empty, because the field shipped an hour ago. It starts paying off as editors fill them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)