### PR TITLE
Give the homepage a stated freshness

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,6 +18,17 @@ const posts = await getHomepageArticles();
 
 const breakingText = posts.breaking_news?.text?.trim() ?? "";
 const breaking = (posts.breaking_news?.enabled ?? false) && breakingText !== "";
+
+// Far shorter than an article page's hour (see ArticleLayout): an article is
+// finished once it publishes, but the homepage is the editors' live control
+// surface -- the featured lead, the breaking banner and the carousel all change
+// on demand and are worth nothing if the edge is holding yesterday's copy.
+// Without this the page states no freshness at all and every cache in front of
+// us invents its own.
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
+);
 ---
 
 <BaseLayout title="The Triangle">

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -26,9 +26,14 @@ export async function getHomepageArticles() {
   //const url = 'https://cms.thetriangle.org/wp-json/triangle/v1/homepage';
   const url = normalizedCmsBaseUrl + '/homepage';
 
+  // Not force-cache, which is "reuse the stored response even when it is
+  // stale": on the one endpoint that carries the featured lead and the breaking
+  // banner that means an editor's change can sit invisible behind a cache entry
+  // with no expiry. 'default' honours the CMS's own Cache-Control (60s), so the
+  // homepage is still cached -- just never past the bound the CMS states.
   const res = await fetch(url, {
     headers: { Accept: 'application/json' },
-    cache: 'force-cache',
+    cache: 'default',
   });
 
   if (!res.ok) throw new Error(String(res.status));


### PR DESCRIPTION
## Why

Companion to [triangle-cms#206](https://github.com/DrexelTriangle/triangle-cms/pull/206), which adds a featured-article toggle so editors can pick the story that runs as the big centre card. That works without any change here — the CMS sorts server-side and `news[0]` is already the lead card — but it exposed that nothing in the chain says how long a copy of the homepage stays good.

The homepage is the editors' live control surface: the featured lead, the breaking banner and the carousel all change on demand. It was the one page sending no `Cache-Control` at all, so every intermediary applied its own heuristic and an editor swapping the lead had no bound on when readers would see it.

## Changes

- **`index.astro` sets `Cache-Control`** — `public, max-age=60, s-maxage=60, stale-while-revalidate=300`, using the same idiom `ArticleLayout` already uses. An hour is right for an article, which is finished once it publishes, and wrong here. `stale-while-revalidate` keeps the short TTL cheap: a spike is still served from cache while one request refreshes it.
- **`getHomepageArticles` drops `force-cache`** — that mode means "reuse the stored response even when it is stale," which on the one endpoint carrying the featured lead and the breaking banner lets an editor's change sit invisible behind an entry with no expiry. `'default'` honours the CMS's own `Cache-Control` (60s, added in the companion PR), so the response is still cached, just never past the bound the CMS states.

The other ~10 `force-cache` call sites are unchanged — only the homepage is time-critical.

## Testing

`astro check` — 0 errors. The CMS side is verified in the companion PR, including a live check that `/v1/homepage` now returns the 60s header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)