### PR TITLE
Take Graduation out of the sticky nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -57,7 +57,8 @@
     <a class="hover:underline" href="/entertainment"> Entertainment </a>
     <a class="hover:underline" href="/comics-puzzles"> Comics </a>
     <a class="hover:underline" href="/classifieds"> Classifieds </a>
-    <a class="relative hover-underline" href="/graduation"> Graduation </a>
+    <!-- Graduation is out of season; uncomment when the issue comes back around. -->
+    <!-- <a class="relative hover-underline" href="/graduation"> Graduation </a> -->
   </nav>
   <SideMenu/>
 </div>


### PR DESCRIPTION
The graduation issue is seasonal, so the tab in the sticky section nav spends most of the year pointing at a stale section. Commented out rather than deleted so it can go back up when the next issue runs.

Only the header nav link is touched — the `Graduation` entry under **Special Editions** in the footer fallback (`src/utils/siteConfig.ts`) is left alone, since the footer menu is CMS-driven and that list is only the offline fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)