### PR TITLE
Keep the scroll sentinel at the bottom of the list

### DIFF
--- a/src/components/Sections/Scroll.astro
+++ b/src/components/Sections/Scroll.astro
@@ -90,7 +90,10 @@
                                 <img src=${article.featured_image ? article.featured_image : "/proxy/wp-content/uploads/2024/12/IMG_2493-2048x1365.jpg"} alt="article image" class="ml-[12px] bg-[url('/images/loading.jpg')] bg-cover w-[calc(100%-12px)] h-[169px] object-cover"/>
                             </article>
                         `;
-                        articlesGrid.appendChild(articleElement);
+                        articlesGrid.insertBefore(
+                            articleElement,
+                            articleLoader,
+                        );
                     });
                 }
             } catch (error) {


### PR DESCRIPTION
## What

On section and author pages, "Loading more articles..." showed up **in the middle** of the article list instead of at the bottom.

## Why

`Scroll.astro` appends each new batch to `#main-left` — but `#article-loader`, the sentinel, is itself a child of `#main-left`. So every fetched batch landed *after* the sentinel, leaving the loading text stranded between the first page and everything loaded since.

This also had a second effect: once the list grew past the sentinel, the sentinel stopped moving down, so it sat permanently inside the `IntersectionObserver`'s `rootMargin` and `checkSentinel` kept re-firing regardless of the reader's actual scroll position.

## Fix

`insertBefore(articleElement, articleLoader)` instead of `appendChild`. The sentinel stays the last child, batches stack above it, and scroll position genuinely gates the next fetch again.

## Testing

Both call sites use the same component, so this covers `/[sectionSlug]` and `/author/[author]`. Worth a scroll through a section page with 14+ articles to confirm the loader stays pinned to the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)