### PR TITLE
Decode the puzzle attribution before inserting it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
         "@eslint/js": "^10.0.1",
+        "@types/he": "^1.2.3",
         "@types/node": "^22.20.1",
         "@types/nodemailer": "^8.0.1",
         "eslint": "^10.7.0",
@@ -4296,6 +4297,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@eslint/js": "^10.0.1",
+    "@types/he": "^1.2.3",
     "@types/node": "^22.20.1",
     "@types/nodemailer": "^8.0.1",
     "eslint": "^10.7.0",

--- a/src/utils/shortcodes.ts
+++ b/src/utils/shortcodes.ts
@@ -13,6 +13,8 @@
  * data-basepath at all.
  */
 
+import he from "he";
+
 /** Attributes are single-quoted in practice, but accept double quotes too. */
 function parseAttributes(raw: string): Record<string, string> {
   const attributes: Record<string, string> = {};
@@ -44,8 +46,12 @@ function puzzlemeEmbed(raw: string): string {
 
   const puzzleType = attributes.type || "crossword";
   // Attribution is authored as HTML (it contains a link), so it is inserted
-  // as-is, exactly as WordPress did.
-  const attribution = attributes.attribution ?? "";
+  // as-is, exactly as WordPress did -- but only WordPress-era bodies hold that
+  // markup raw. A post written in the CMS editor stores the shortcode with the
+  // attribution entity-encoded ("&lt;a href=..."), which printed the tags as
+  // visible text under the puzzle. Decoding first gives both shapes the same
+  // markup to insert; on a legacy body with no entities it is a no-op.
+  const attribution = he.decode(attributes.attribution ?? "");
   const attributionDiv = attribution
     ? `\n            <div class="pm-attribution-div" style="font-family: sans-serif;font-size: 12px;color:#666666;padding-top: 5px;width: 100%">${attribution}</div>`
     : "";


### PR DESCRIPTION
Follow-up to #77, same article. The attribution line under "What's on Tea-V?" renders its own markup as visible text:

> Made by Coco Li using the online `<a href="https://amuselabs.com/games/crossword/" target="_blank" style="color: #666666; text-decoration: underline;">`cross word generator`</a>` from Amuse Labs

The attribution is authored as HTML — it carries a link to the generator — and WordPress inserted it as-is, which is what `puzzlemeEmbed` does. But only WordPress-era bodies hold that markup raw: a post written in the CMS editor stores the shortcode with the attribution entity-encoded (`&lt;a href=…`), so the tags and inline styles reach the page verbatim.

Decoding before insertion gives both shapes the same markup to insert. Verified against the stored body of 10092 (encoded) and a legacy-shaped shortcode (raw), where it is a no-op.

`@types/he` comes along because `shortcodes.ts` is the first TypeScript module to import `he` — the existing caller is plain JS, so `astro check` never had to resolve its types before. `astro check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)