### PR TITLE
Keep inline-image paragraphs at the body text size

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,16 +141,22 @@ body {
 }
 
 /*
- * The body typeface lives on the container, not on the per-block rule below.
- * That rule has to sniff each block's contents to tell prose from layout
+ * The body typeface *and size* live on the container, not on the per-block rule
+ * below. That rule has to sniff each block's contents to tell prose from layout
  * wrappers, and a block can stop matching for reasons outside our control --
  * flytedesk injects its in-content ad units *inside* a paragraph, which used to
  * drop that paragraph out of the rule and let it inherit body's generic serif
- * (Times on iOS). Anchoring the font here means a mis-sniffed block can lose
- * its measure but never its face.
+ * (Times on iOS).
+ *
+ * The face was anchored here first; the size had to follow for the same reason.
+ * A paragraph that embeds an image inline is a real prose block, but it trips
+ * the :has(figure) clause below and falls out of the rule, and body is 18px --
+ * so those paragraphs rendered two points larger than the ones around them, in
+ * the same article. Anchoring both means a mis-sniffed block can lose its
+ * measure but never its face or its size.
  */
 #article {
-  @apply font-roboto-slab;
+  @apply font-roboto-slab text-[16px];
 }
 
 /*


### PR DESCRIPTION
Fixes the inconsistent text sizing reported on a Pixel phone.

## The bug

Body prose gets `text-[16px]` from a rule that has to tell prose blocks from layout wrappers by sniffing their contents:

```css
#article > div:not(.article-embed, :has(figure, table, script), ...)
```

A paragraph with an **image embedded inline** is real prose, but it carries a `<figure>`, trips `:has(figure)`, and drops out of the rule. It then inherits `body { font-size: 18px }` — so those paragraphs render two points larger than the ones around them, in the same article.

This is the same failure mode as the earlier `font-family` fix (b24e9b7), which named the gap it was leaving:

> a mis-sniffed block can lose its measure but never its face

The size stayed on the sniffing rule, so it stayed exposed. This moves it onto the container too, which covers the inline-image case *and* any future one — rather than adding another clause to a guard that will never be fully reliable.

```diff
 #article {
-  @apply font-roboto-slab;
+  @apply font-roboto-slab text-[16px];
 }
```

## Scope

Only Trix/CMS bodies can hit this; legacy WordPress prose is `<p>`, which matches unconditionally. I scanned **1,233 prod articles** (all 833 from 2026 plus a 400-article archive sample) — `amada-review` is the only current hit, but it recurs whenever an image is inlined into a paragraph.

Mobile-only in practice: the rule also grants `max-w-[700px]`, and at phone width the column is already narrower than 700px, so size is the only visible symptom.

## Verification

Live prod markup, Chromium at Pixel 9 viewport (412px), real ad scripts running:

| block | before | after |
|---|---|---|
| "Located on Chestnut Street, Amada brings…" | 18px | **16px** |
| "Another seafood dish was the gambas…" | 18px | **16px** |
| "The meat selections got off to a strong…" | 18px | **16px** |
| "Besides tapas, Amada also offers paella…" | 16px | 16px |
| "The Triangle was invited by Champion…" | 16px | 16px |

Shipped vs. rebuilt stylesheet:
```
prod:  #article{font-family:Roboto Slab,serif}
fixed: #article{font-family:Roboto Slab,serif;font-size:16px}
```

**No regressions:** a full before/after node diff across a review, a sudoku and two ordinary articles shows **no width change anywhere** (`366->366`), so the puzzle embed the guard protects is untouched, and figcaptions hold their explicit 12px.

Also confirmed the ad path is still clean — `.flytead` units inject into paragraphs on all three articles tested and those paragraphs keep 16px.

## Known, deliberately not fixed here

Those paragraphs also lose `max-w-[700px]`, so they run full-bleed on desktop. Invisible on a phone. Narrowing `:has(figure)` risks squeezing the puzzle embed into the prose column, which is exactly what that clause exists to prevent — worth a separate change.

## Caveat

The Android emulator segfaulted on boot (exit 139, three GPU backends; KVM healthy, nothing in the kernel log), so this was diagnosed against live prod in Chromium at Pixel 9 viewport rather than real Android Chrome. The cause found is device-independent and reproduces in any browser, but that can't fully rule out a second Android-specific cause. Worth a look on a real device once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)