### PR TITLE
Wake the header controls and poll up on article pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -73,7 +73,8 @@
     const subNav = document.getElementById("sub-nav");
 
     // Toggle fa-bars and fa-close on hamburger click
-    if (hamburger && sideNav && mainNav && subNav) {
+    if (hamburger && sideNav && mainNav && subNav && !hamburger.dataset.bound) {
+      hamburger.dataset.bound = "1";
       hamburger.addEventListener('click', () => {
         if (hamburger.classList.contains('fa-bars')) {
           hamburger.classList.remove('fa-bars');
@@ -98,7 +99,8 @@
       });
     }
 
-    if (search && searchBar) {
+    if (search && searchBar && !search.dataset.bound) {
+      search.dataset.bound = "1";
       search.addEventListener('click', () => {
         searchBar.classList.toggle("hiddenSearch");
       });
@@ -134,10 +136,23 @@
 
   window.addEventListener('scroll', onScroll);
 
-  document.addEventListener("astro:page-load", () => {
+  function initHeader() {
     setupHeader();
     onScroll();
-  });
+  }
+
+  // Article pages render through ArticleLayout, which has no <ClientRouter />,
+  // so astro:page-load never fires there. Binding on that event alone left the
+  // hamburger and search icon dead on every article. Bind on plain DOM readiness
+  // too; setupHeader() marks the elements it wires so the extra call on
+  // ClientRouter pages is a no-op.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initHeader);
+  } else {
+    initHeader();
+  }
+
+  document.addEventListener("astro:page-load", initHeader);
 
       // let idx = 0;
       // setInterval(() => {

--- a/src/components/Polls.astro
+++ b/src/components/Polls.astro
@@ -53,6 +53,15 @@ const totalVotes = Object.values(pollOptionCounts).reduce((sum, count) => sum + 
   // fall back to a native GET submit (/?poll=Yes) and no vote would be cast.
   const setupPoll = () => {
     const pollRoot = document.querySelector<HTMLElement>('[data-poll-root]');
+    // Article pages render through ArticleLayout, which has no <ClientRouter />,
+    // so astro:page-load never fires there and none of this ran. setupPoll is now
+    // also called on DOM readiness; this flag keeps the second call on
+    // ClientRouter pages from binding the submit handler twice.
+    if (!pollRoot || pollRoot.dataset.bound) {
+      return;
+    }
+    pollRoot.dataset.bound = '1';
+
     const pollForm = pollRoot?.querySelector<HTMLFormElement>('[data-poll-form]');
     const userVoteNode = pollRoot?.querySelector<HTMLElement>('[data-user-vote]');
     const submitButton = pollForm?.querySelector<HTMLButtonElement>('button[type="submit"]');
@@ -202,6 +211,12 @@ const totalVotes = Object.values(pollOptionCounts).reduce((sum, count) => sum + 
       updateOptionBackgrounds(counts);
     });
   };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupPoll);
+  } else {
+    setupPoll();
+  }
 
   document.addEventListener('astro:page-load', setupPoll);
 </script>


### PR DESCRIPTION
## Problem

Inside an article (`/article/*`), the hamburger menu and the search icon do nothing when clicked, and the poll form casts no vote.

`Header.astro` and `Polls.astro` bind their listeners only inside a `document.addEventListener("astro:page-load", …)` handler. That event is emitted by `<ClientRouter />`, which `BaseLayout.astro` renders and `ArticleLayout.astro` does not — so on article pages the scripts load (confirmed in the served HTML) and then bind nothing.

The header's `scroll` listener is registered at module scope, which is why the icons still reposition as you scroll while staying inert on click. The poll form falls back to a native GET submit (`/?poll=Yes`).

## Fix

Initialize on plain DOM readiness in addition to `astro:page-load`, with a `data-bound` flag on the hamburger, the search icon, and the poll root. On `ClientRouter` pages both `DOMContentLoaded` and `astro:page-load` fire on first load, and without the flag the hamburger would bind twice and toggle itself straight back shut.

Element identity is what carries the flag, so a client-side navigation — which swaps in fresh DOM — still rebinds normally.

## Why not just add `<ClientRouter />` to `ArticleLayout`

It would fix both at once, but `ArticleLayout` carries its own inline Matomo snippet bound to *both* `DOMContentLoaded` and `astro:page-load`. Enabling view transitions there would double-count every article pageview.

## Testing

- `npx astro check` — 0 errors.
- Served `/article/drexel-university-student-arrested-in-utah-for-terroristic-threats` from the dev server to confirm the header script is present on the page while `ClientRouter` is not — the exact condition the fix targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)