### PR TITLE
Space inline figures off the text around them

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -132,8 +132,23 @@ body {
   object-fit:cover;
 }
 
+/*
+ * Trix bodies keep their images *inside* the paragraph div rather than beside
+ * it, so an inline <figure> has no prose sibling whose margin could space it
+ * off the text above. Own the gap here instead of leaning on the neighbours;
+ * where a <p> is the neighbour the two margins just collapse to the same 16px.
+ *
+ * The trailing <br> is what the editor left behind when the figure was dropped
+ * mid-paragraph. It sits after a block element, so it buys nothing but a stray
+ * empty line under the caption.
+ */
 #article figure{
   max-width: 100% !important;
+  @apply my-[16px];
+}
+
+#article figure + br{
+  display: none;
 }
 
 #article figure figcaption{


### PR DESCRIPTION
Reported on [/article/amada-review](https://www.thetriangle.org/article/amada-review): images in the body sit flush against the paragraph above them, with no gap.

## Cause

That article is a Trix-authored body, so the whole thing is one `<div>` with `<br><br>` between paragraphs and the figures *inside* it:

```html
<div>…making it another simple yet delicious offering. <figure class="wp-caption">…</figure></div>
```

`#article figure` never had vertical margin — only the prose blocks (`#article p`, `#article > div`) do. On legacy WordPress bodies that's invisible, because the figure is a *sibling* of the `<p>`s and borrows their margins. Inline in a Trix div there is no prose sibling to borrow from, so the figure gets zero.

## Fix

Give the figure its own `my-[16px]`. Where a `<p>` is the neighbour the two margins collapse to the same 16px, so legacy bodies render identically.

Also hides the `<br>` the editor leaves directly after an inline figure — it follows a block element, so it only adds an empty line under the caption and makes the spacing lopsided.

## Verification

Astro dev server against the live CMS API, same article, before/after. Before: caption and image flush against the paragraphs on both sides. After: an even 16px above and below every figure, and legacy `<p>`-based articles unchanged. Images 404 in headless, so the figures render zero-height — which makes the margin itself easy to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)