### PR TITLE
Route section slugs from the taxonomy instead of probing for them

### DIFF
--- a/src/pages/[sectionSlug].astro
+++ b/src/pages/[sectionSlug].astro
@@ -10,19 +10,42 @@ import Social from "../components/Social.astro";
 import Poll from "../components/Polls.astro";
 import "../styles/global.css";
 import { getSectionArticles, getSubsectionArticles } from "../utils/db";
+import { getSlugKind } from "../utils/taxonomyStore";
+import type { SectionArticles, Subsection } from "../utils/types";
 import { normalizeText } from "../utils/data";
 import Scroll from "../components/Sections/Scroll.astro";
 import SubscribeLink from "../components/SubscribeLink.astro";
 
 const pageNum = 1;
-let posts = sectionSlug ? await getSectionArticles(sectionSlug, pageNum) : undefined;
+
+// This route is the site's root-level catch-all, so it sees subsections,
+// sections and every stray path alike (/sw.js used to land here). Ask the
+// taxonomy which one this is and call only that endpoint: probing the section
+// endpoint first and falling through on failure cost every subsection page a
+// wasted CMS round trip, and every unknown path two.
+const slugKind = sectionSlug ? await getSlugKind(sectionSlug) : "unknown";
+
+let posts: SectionArticles | undefined;
 let isSubsectionPage = false;
 
-if (!posts && sectionSlug) {
-    posts = await getSubsectionArticles(sectionSlug, pageNum);
-    isSubsectionPage = Boolean(posts);
+if (sectionSlug) {
+    if (slugKind === "section") {
+        posts = await getSectionArticles(sectionSlug, pageNum);
+    } else if (slugKind === "subsection") {
+        posts = await getSubsectionArticles(sectionSlug, pageNum);
+        isSubsectionPage = Boolean(posts);
+    } else if (slugKind === "unavailable") {
+        // The taxonomy could not be read. Fall back to the old probe rather
+        // than 404: a CMS blip must not take every section page down with it.
+        posts = await getSectionArticles(sectionSlug, pageNum);
+        if (!posts) {
+            posts = await getSubsectionArticles(sectionSlug, pageNum);
+            isSubsectionPage = Boolean(posts);
+        }
+    }
 }
 
+// "unknown" lands here having made no article request at all.
 if (!posts) {
     return Astro.rewrite("/404");
 }
@@ -33,6 +56,10 @@ const sectionName = normalizeText(
 );
 
 let hasMore = posts.pagination.has_more;
+
+// The nav strip lists a section's subsections; a subsection page has none of
+// its own to show.
+const subsectionLinks: Subsection[] = isSubsectionPage ? [] : (posts.subsections ?? []);
 ---
 
 <BaseLayout title={sectionName + " - The Triangle"}>
@@ -46,7 +73,7 @@ let hasMore = posts.pagination.has_more;
         class="hidden sm:flex xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] font-roboto-slab font-light text-[12px] gap-x-[16px] border-b-[1px] border-solid border-triangleGray"
     >
         {
-            (!isSubsectionPage ? posts.subsections : [])?.map((subsection) => (
+            subsectionLinks.map((subsection) => (
                 <a href={"/" + subsection.slug} class="hover:border-triangleBlue border-transparent border-b-[1px] pb-[4px]">
                     {" "}
                     {normalizeText(subsection.canonical_title ?? subsection.name)}

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -9,6 +9,7 @@
  * @typedef {import('./types').SitemapSlug} SitemapSlug
  * @typedef {import('./types').ClassifiedPost} ClassifiedPost
  * @typedef {import('./types').ArticleComments} ArticleComments
+ * @typedef {import('./types').TaxonomyItem} TaxonomyItem
  */
 
 import { stripShortcodes } from "./shortcodes";
@@ -102,6 +103,35 @@ export async function getSectionArticles(section, page) {
 
   if (!res.ok) return;
   return sanitizeExcerpts(await res.json());
+}
+
+/**
+ * Every section, subsection and tag the CMS knows about, in one response
+ * (~52 rows / 8 KB today). Distinguishes a section slug from a subsection slug
+ * without asking the article endpoints, which is otherwise only answerable by
+ * calling one and seeing it fail.
+ *
+ * Go through taxonomyStore rather than calling this directly: it sits on the
+ * path of every section page, and this function has no cache of its own.
+ * Returns undefined on failure, so a caller can tell an unreachable CMS from a
+ * genuinely empty taxonomy.
+ * @returns {Promise<TaxonomyItem[]|undefined>}
+ */
+export async function getTaxonomy() {
+  const url = normalizedCmsBaseUrl + '/taxonomy';
+
+  // no-store, unlike its neighbours: /v1/taxonomy states no Cache-Control, and
+  // force-cache with nothing to respect would pin the first response for the
+  // life of the process -- a new section would never appear. Freshness is
+  // taxonomyStore's job, where there is an explicit TTL.
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) return;
+  const body = await res.json();
+  return Array.isArray(body) ? body : undefined;
 }
 
 export async function getSubsectionArticles(subsection, page) {

--- a/src/utils/taxonomyStore.ts
+++ b/src/utils/taxonomyStore.ts
@@ -1,0 +1,136 @@
+// Server-side cache of the CMS taxonomy, used to route a root-level slug to
+// the right article endpoint.
+//
+// Without it the only way to tell /politics (a subsection) from /news (a
+// section) is to call the section endpoint and see it fail, which costs every
+// subsection page a wasted CMS round trip and puts a permanent error floor
+// under the production metrics -- around 1000 failed requests a day, enough to
+// make the error-rate panel useless for alerting. Unknown slugs are worse:
+// /sw.js and every other stray root path cost two failures before reaching 404.
+//
+// Like weatherStore, this module is shared across requests because the node
+// adapter runs a single long-lived process.
+
+import { getTaxonomy } from './db';
+import type { TaxonomyItem } from './types';
+
+/** The taxonomy changes when an editor adds a section, which is rare. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+/** After a failure with nothing to serve, retry sooner. */
+const ERROR_BACKOFF_MS = 30 * 1000;
+/** Keep serving a stale taxonomy this long if the CMS is down. */
+const STALE_MAX_MS = 60 * 60 * 1000;
+
+/**
+ * What a root-level slug turned out to be.
+ *
+ * `unknown` means the CMS answered and the slug is in neither list, so the
+ * caller can go straight to 404 without touching the CMS again. `unavailable`
+ * means we could not find out -- distinct from `unknown`, because sending every
+ * section page to 404 during a CMS blip would be far worse than the wasted
+ * round trip this module exists to remove.
+ */
+export type SlugKind = 'section' | 'subsection' | 'unknown' | 'unavailable';
+
+type SlugKinds = Map<string, 'section' | 'subsection'>;
+
+type CacheEntry = {
+  /** null when the last attempt failed and we have nothing to serve. */
+  kinds: SlugKinds | null;
+  fetchedAt: number;
+};
+
+let cache: CacheEntry | null = null;
+/** Dedupes concurrent misses so a burst of traffic makes one upstream call. */
+let inFlight: Promise<CacheEntry> | null = null;
+
+function indexBySlug(items: TaxonomyItem[]): SlugKinds {
+  const kinds: SlugKinds = new Map();
+
+  for (const item of items) {
+    if (item?.type !== 'section' && item?.type !== 'subsection') continue;
+    if (typeof item.slug !== 'string' || !item.slug) continue;
+    // Sections win a collision, matching the order the old probe tried them in.
+    if (item.type === 'subsection' && kinds.has(item.slug)) continue;
+    kinds.set(item.slug, item.type);
+  }
+
+  return kinds;
+}
+
+async function fetchKinds(): Promise<SlugKinds | null> {
+  try {
+    const items = await getTaxonomy();
+    if (!items) {
+      console.error('Taxonomy: CMS did not return a usable /v1/taxonomy payload.');
+      return null;
+    }
+
+    const kinds = indexBySlug(items);
+    if (kinds.size === 0) {
+      // A CMS that answers with no sections at all is a broken CMS, not a site
+      // with no sections. Treat it as a failure so routing falls back to
+      // probing rather than 404ing every section page.
+      console.error('Taxonomy: /v1/taxonomy held no sections or subsections.');
+      return null;
+    }
+
+    return kinds;
+  } catch (err) {
+    console.error('Taxonomy: fetch failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+function isFresh(entry: CacheEntry, now: number): boolean {
+  const ttl = entry.kinds === null ? ERROR_BACKOFF_MS : CACHE_TTL_MS;
+  return now - entry.fetchedAt < ttl;
+}
+
+async function loadKinds(): Promise<SlugKinds | null> {
+  const now = Date.now();
+
+  if (cache && isFresh(cache, now)) {
+    return cache.kinds;
+  }
+
+  if (!inFlight) {
+    inFlight = fetchKinds()
+      .then((kinds) => {
+        // If this attempt failed but we still hold a recent-enough taxonomy,
+        // keep using it. A stale taxonomy is very likely still correct, and it
+        // beats routing on guesses.
+        if (kinds === null && cache?.kinds && now - cache.fetchedAt < STALE_MAX_MS) {
+          return { kinds: cache.kinds, fetchedAt: now };
+        }
+        return { kinds, fetchedAt: now };
+      })
+      .then((entry) => {
+        cache = entry;
+        return entry;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+
+  const entry = await inFlight;
+  return entry.kinds;
+}
+
+/**
+ * Classify a root-level slug. Never throws; returns 'unavailable' when the
+ * taxonomy could not be read, which callers should treat as "find out the
+ * expensive way" rather than "not found".
+ *
+ * Matching is exact, which is what the article endpoints do too -- /News does
+ * not resolve to the News section here or in the CMS.
+ */
+export async function getSlugKind(slug: string): Promise<SlugKind> {
+  if (!slug) return 'unknown';
+
+  const kinds = await loadKinds();
+  if (!kinds) return 'unavailable';
+
+  return kinds.get(slug) ?? 'unknown';
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -251,6 +251,23 @@ export interface ArticleComments {
   total_count: number;
 }
 
+/**
+ * triangle-cms: one row of the CMS's site_taxonomy. `/v1/taxonomy` returns
+ * these as a bare array -- sections, subsections and tags together, so callers
+ * that care about one kind have to filter on `type`.
+ */
+export interface TaxonomyItem {
+  id: number;
+  type: 'section' | 'subsection' | 'tag';
+  slug: string;
+  canonical_title: string;
+  /** Set on subsections: the slug of the section they hang under. */
+  parent_slug?: string;
+  article_count: number;
+  /** Extra category titles whose articles also belong to this item. */
+  category_aliases: string[];
+}
+
 /** triangle-cms: an approved classified from /v1/classifieds. */
 export interface ClassifiedPost {
   id: number;


### PR DESCRIPTION
`[sectionSlug].astro` is the site's root-level catch-all and had no way to tell a section slug from a subsection slug, so it called the section endpoint and treated failure as the answer:

```js
let posts = sectionSlug ? await getSectionArticles(sectionSlug, pageNum) : undefined;
if (!posts && sectionSlug) {
    posts = await getSubsectionArticles(sectionSlug, pageNum);
    isSubsectionPage = Boolean(posts);
}
```

Every subsection page cost a wasted CMS round trip; every stray root path — `/sw.js`, `/podcasts` — cost two before reaching 404. Measured on Delta over 6h on 2026-08-06: **720** failed section-listing requests plus **326** failed subsection ones, roughly a thousand a day. That keeps the production error-rate panel near 5% permanently, which makes it useless for alerting.

## The fix

`GET /v1/taxonomy` answers the question directly — one ~8 KB response covering all 52 sections and subsections. New `src/utils/taxonomyStore.ts` caches it per process behind a 5-minute TTL, following the `weatherStore` pattern already in the repo: in-flight dedupe so a traffic burst makes one upstream call, a short backoff after failure, and a stale entry kept usable for an hour.

`getTaxonomy()` in `db.js` uses `cache: 'no-store'`, unlike its neighbours. `/v1/taxonomy` states no `Cache-Control`, so `force-cache` with nothing to respect would pin the first response for the life of the process and a new section would never appear. Freshness belongs in the store, where there is an actual TTL.

## `unknown` vs `unavailable`

`getSlugKind()` returns four values, and the last two must not be conflated:

- **`unknown`** — the CMS answered and the slug is in neither list. Go straight to 404, having made no article request at all.
- **`unavailable`** — the lookup itself failed. Fall back to the old probe. Sending every section page to 404 during a CMS blip would be far worse than the round trip this PR removes.

A CMS that answers with an empty taxonomy is treated as a failure too, not as a site with no sections.

## Verification

Against the live Delta CMS through a logging proxy, counting the requests each page load makes:

| Path | Before | After |
| --- | --- | --- |
| `/news` (section) | 1 | 1 |
| `/politics` (subsection) | 2 (1 failing) | **1** |
| `/sw.js` | 2 (both failing) | **0** |
| `/podcasts` (in neither list) | 2 (both failing) | **0** |

Rendering is unchanged: `/news` and `/sports` show their subsection nav strips (7 and 9 links), `/politics` renders as a subsection with the right title and no strip, so `isSubsectionPage` semantics are intact.

Failure paths were exercised by forcing `/v1/taxonomy` to 503:

- With a warm cache, `/politics` still routed straight to the subsection endpoint from the stale entry — no probing — and the next page load did not even re-attempt the fetch, per the backoff.
- With a cold cache, `/news` and `/politics` both still served 200 via the probe fallback.
- Both recovered to single-call routing on the next successful fetch.

`npm run lint` clean, `astro check` 0 errors / 0 warnings (8 pre-existing hints), build clean.

## Notes

- The CMS now returns **404** rather than 400 for unknown section/subsection slugs — the counterpart card has already shipped, so the card's "400" figures are historical. The wasted round trip was the real cost either way.
- Of the three slugs the card lists as absent from the taxonomy, `tri-this-sweet-treat` is now a valid subsection. `podcasts` and `sjn-grant` are still genuinely absent and now go straight to `/404` instead of being masked by a double failure.
- `/v1/taxonomy` did not get a `Cache-Control` header in the CMS's recent public-cache pass. Worth adding on the CMS side; the store does not depend on it.

Card: https://app.notion.com/p/3b48ed235ed3810a9095cd952f66b128

🤖 Generated with [Claude Code](https://claude.com/claude-code)