### PR TITLE
Stop linking article categories that are not pages

### DIFF
--- a/src/components/PhotoArticle.astro
+++ b/src/components/PhotoArticle.astro
@@ -1,5 +1,6 @@
 ---
 import { normalizeText, buildByline, proxyMediaUrl } from '../utils/data';
+import { getCategoryHref } from '../utils/taxonomyStore';
 
 const { title, excerpt, image, author, published_date, date, category, row, slug, breaking } = Astro.props;
 
@@ -15,6 +16,10 @@ if (image !== undefined) {
 }
 
 const byline = buildByline(author, published_date || date);
+
+// Most WordPress categories are not pages of their own, so the label only gets
+// an href where the taxonomy says it leads somewhere. See getCategoryHref.
+const categoryHref = category ? await getCategoryHref(category[0]) : null;
 
 const classes = row
   ? 'mb-[4px] md:mb-[0px] flex-1 sm:px-[16px] first:pl-0 sm:last:pr-0'
@@ -32,7 +37,7 @@ const imgClass = row
     </a>
   )}
   {category && (
-    <a href={`/${category[0].slug}`}>
+    <a href={categoryHref ?? undefined}>
       <h3 class="font-roboto-slab uppercase font-extrabold text-triangleBlue text-[10px] font-700">
         {normalizeText(category[0].name)}
       </h3>

--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -10,6 +10,7 @@ import '../../styles/global.css';
 import Social from '../../components/Social.astro';
 import Poll from '../../components/Polls.astro';
 import { getArticle, getArticleComments } from '../../utils/db';
+import { getCategoryHref } from "../../utils/taxonomyStore";
 import { normalizeText } from "../../utils/data";
 import { expandShortcodes } from "../../utils/shortcodes";
 import { normalizeArticleHtml } from "../../utils/articleHtml";
@@ -162,6 +163,9 @@ const articleHtml = describeLeadImage(stripDimensions(proxyWpContent(content)));
 // broken across lines still counts.
 const actualArticle = /<(p|div|blockquote|h[1-6])(\s[^>]*)?>\s*[^<\s][\s\S]*?<\/\1>/i.test(content);
 const primaryCategory = post.categories?.[0] ?? post.categories_list?.[0];
+// Most WordPress categories are not pages of their own. Link the kicker only
+// where the taxonomy says the label leads somewhere; otherwise plain text.
+const primaryCategoryHref = await getCategoryHref(primaryCategory);
 
 // Puzzle posts set a screenshot of the puzzle as their featured image so they
 // have a thumbnail in section lists and social cards, but on the article page
@@ -181,7 +185,10 @@ const featuredImage =
     <Header/>
     <span class="hidden print:block text-center uppercase text-[14px] mb-[12px]"> THE TRIANGLE &nbsp; <b>{normalizeText(primaryCategory?.name ?? "")}</b> &nbsp; {date_string} </span>
     <article class="xl:max-w-[1200px] lg:max-w-[1000px] max-w-[90%] mx-[auto]">
-        {primaryCategory && <a href={"../"+primaryCategory.slug}><span class="block font-roboto-slab uppercase font-extrabold text-triangleBlue text-[12px] md:text-[14px] italic font-700"> {normalizeText(primaryCategory.name)} </span></a>}
+        {/* No href when the category is not a page: Astro drops the attribute,
+            leaving a plain <a> -- which is what HTML has for a link that is not
+            currently active, and renders as the same unlinked kicker text. */}
+        {primaryCategory && <a href={primaryCategoryHref ?? undefined}><span class="block font-roboto-slab uppercase font-extrabold text-triangleBlue text-[12px] md:text-[14px] italic font-700"> {normalizeText(primaryCategory.name)} </span></a>}
         <h1 class="font-playfair text-[28px] sm:text-[36px] md:text-[42px] font-bold md:mt-[-12px] leading-[normal]">{normalizeText(post.title)}</h1>
         <div set:html={authorList} class="text-[14px] md:text-[16px] font-roboto-slab font-light print:hidden"></div>
         <span class="font-light font-roboto-slab text-[12px] mb-[16px] print:hidden">{date_string}</span>

--- a/src/utils/taxonomyStore.ts
+++ b/src/utils/taxonomyStore.ts
@@ -1,5 +1,6 @@
-// Server-side cache of the CMS taxonomy, used to route a root-level slug to
-// the right article endpoint.
+// Server-side cache of the CMS taxonomy, used to answer two routing questions
+// the site cannot answer on its own: what a root-level slug is, and where an
+// article's category label should link.
 //
 // Without it the only way to tell /politics (a subsection) from /news (a
 // section) is to call the section endpoint and see it fail, which costs every
@@ -34,9 +35,25 @@ export type SlugKind = 'section' | 'subsection' | 'unknown' | 'unavailable';
 
 type SlugKinds = Map<string, 'section' | 'subsection'>;
 
+/**
+ * Category title (lowercased) -> the routable slug that owns it.
+ *
+ * The CMS records the category titles an imported article carries for a section
+ * it does not name directly: Columns owns "Podcasts", Entertainment owns
+ * "Arts & Entertainment", Sports owns "Men's Lacrosse" and a dozen more.
+ * Article pages label themselves with the raw category, so this is what turns
+ * that label into a link that goes somewhere.
+ */
+type AliasOwners = Map<string, string>;
+
+type Taxonomy = {
+  kinds: SlugKinds;
+  aliases: AliasOwners;
+};
+
 type CacheEntry = {
   /** null when the last attempt failed and we have nothing to serve. */
-  kinds: SlugKinds | null;
+  taxonomy: Taxonomy | null;
   fetchedAt: number;
 };
 
@@ -44,21 +61,31 @@ let cache: CacheEntry | null = null;
 /** Dedupes concurrent misses so a burst of traffic makes one upstream call. */
 let inFlight: Promise<CacheEntry> | null = null;
 
-function indexBySlug(items: TaxonomyItem[]): SlugKinds {
+function indexTaxonomy(items: TaxonomyItem[]): Taxonomy {
   const kinds: SlugKinds = new Map();
+  const aliases: AliasOwners = new Map();
 
   for (const item of items) {
     if (item?.type !== 'section' && item?.type !== 'subsection') continue;
     if (typeof item.slug !== 'string' || !item.slug) continue;
+
     // Sections win a collision, matching the order the old probe tried them in.
-    if (item.type === 'subsection' && kinds.has(item.slug)) continue;
-    kinds.set(item.slug, item.type);
+    if (!(item.type === 'subsection' && kinds.has(item.slug))) {
+      kinds.set(item.slug, item.type);
+    }
+
+    for (const alias of item.category_aliases ?? []) {
+      if (typeof alias !== 'string') continue;
+      const key = alias.trim().toLowerCase();
+      // Same precedence: the first owner of a title keeps it.
+      if (key && !aliases.has(key)) aliases.set(key, item.slug);
+    }
   }
 
-  return kinds;
+  return { kinds, aliases };
 }
 
-async function fetchKinds(): Promise<SlugKinds | null> {
+async function fetchTaxonomy(): Promise<Taxonomy | null> {
   try {
     const items = await getTaxonomy();
     if (!items) {
@@ -66,8 +93,8 @@ async function fetchKinds(): Promise<SlugKinds | null> {
       return null;
     }
 
-    const kinds = indexBySlug(items);
-    if (kinds.size === 0) {
+    const taxonomy = indexTaxonomy(items);
+    if (taxonomy.kinds.size === 0) {
       // A CMS that answers with no sections at all is a broken CMS, not a site
       // with no sections. Treat it as a failure so routing falls back to
       // probing rather than 404ing every section page.
@@ -75,7 +102,7 @@ async function fetchKinds(): Promise<SlugKinds | null> {
       return null;
     }
 
-    return kinds;
+    return taxonomy;
   } catch (err) {
     console.error('Taxonomy: fetch failed:', err instanceof Error ? err.message : err);
     return null;
@@ -83,27 +110,27 @@ async function fetchKinds(): Promise<SlugKinds | null> {
 }
 
 function isFresh(entry: CacheEntry, now: number): boolean {
-  const ttl = entry.kinds === null ? ERROR_BACKOFF_MS : CACHE_TTL_MS;
+  const ttl = entry.taxonomy === null ? ERROR_BACKOFF_MS : CACHE_TTL_MS;
   return now - entry.fetchedAt < ttl;
 }
 
-async function loadKinds(): Promise<SlugKinds | null> {
+async function loadTaxonomy(): Promise<Taxonomy | null> {
   const now = Date.now();
 
   if (cache && isFresh(cache, now)) {
-    return cache.kinds;
+    return cache.taxonomy;
   }
 
   if (!inFlight) {
-    inFlight = fetchKinds()
-      .then((kinds) => {
+    inFlight = fetchTaxonomy()
+      .then((taxonomy) => {
         // If this attempt failed but we still hold a recent-enough taxonomy,
         // keep using it. A stale taxonomy is very likely still correct, and it
         // beats routing on guesses.
-        if (kinds === null && cache?.kinds && now - cache.fetchedAt < STALE_MAX_MS) {
-          return { kinds: cache.kinds, fetchedAt: now };
+        if (taxonomy === null && cache?.taxonomy && now - cache.fetchedAt < STALE_MAX_MS) {
+          return { taxonomy: cache.taxonomy, fetchedAt: now };
         }
-        return { kinds, fetchedAt: now };
+        return { taxonomy, fetchedAt: now };
       })
       .then((entry) => {
         cache = entry;
@@ -115,7 +142,7 @@ async function loadKinds(): Promise<SlugKinds | null> {
   }
 
   const entry = await inFlight;
-  return entry.kinds;
+  return entry.taxonomy;
 }
 
 /**
@@ -129,8 +156,39 @@ async function loadKinds(): Promise<SlugKinds | null> {
 export async function getSlugKind(slug: string): Promise<SlugKind> {
   if (!slug) return 'unknown';
 
-  const kinds = await loadKinds();
-  if (!kinds) return 'unavailable';
+  const taxonomy = await loadTaxonomy();
+  if (!taxonomy) return 'unavailable';
 
-  return kinds.get(slug) ?? 'unknown';
+  return taxonomy.kinds.get(slug) ?? 'unknown';
+}
+
+/** The `{ name, slug }` shape every CMS payload uses for an article category. */
+type ArticleCategory = { name?: string; slug?: string };
+
+/**
+ * Where an article's category label should link, or null if nowhere.
+ *
+ * An article carries whatever category WordPress gave it, and most of those are
+ * not pages. 273 articles name a primary category that is not a section or a
+ * subsection -- `wrestling` (103), `triangle-talks` (72), `theater` (25),
+ * `sjn-grant` (9) -- and the kicker above their headline used to link to it
+ * regardless, so every one of those articles shipped a link to a 404.
+ *
+ * Resolution order: the slug itself if it is routable, then the category title
+ * against the taxonomy's alias map ("Podcasts" -> /columns). Null means the
+ * caller should render the label as plain text rather than a dead link.
+ */
+export async function getCategoryHref(category: ArticleCategory | undefined): Promise<string | null> {
+  if (!category) return null;
+
+  const taxonomy = await loadTaxonomy();
+  // With no taxonomy to check against, keep the old behaviour and link to the
+  // slug: a link that might 404 beats dropping every category link site-wide
+  // for as long as the CMS is unreachable.
+  if (!taxonomy) return category.slug ? `/${category.slug}` : null;
+
+  if (category.slug && taxonomy.kinds.has(category.slug)) return `/${category.slug}`;
+
+  const owner = category.name && taxonomy.aliases.get(category.name.trim().toLowerCase());
+  return owner ? `/${owner}` : null;
 }


### PR DESCRIPTION
**Stacked on #83** — base it there, merge after. It reuses the taxonomy store that PR introduces.

## The bug

Every article page labels itself with its primary category and links that label to `/<category-slug>` — the kicker above the headline ([\[article\].astro:184](src/pages/[sections]/[article].astro#L184)) and the related-article cards ([PhotoArticle.astro:35](src/components/PhotoArticle.astro#L35)). Most WordPress categories are not sections, so the link goes nowhere.

Scanning all 10,049 imported articles: **273 carry a primary category that is absent from `site_taxonomy`.**

| Category | Articles | | Category | Articles |
| --- | --- | --- | --- | --- |
| `wrestling` | 103 | | `dear-granny-and-eloise` | 11 |
| `triangle-talks` | 72 | | `sjn-grant` | 9 |
| `theater` | 25 | | `movies-i-ve-seen` | 4 |
| `sadie-says` | 18 | | `triangle-sports-talk` | 3 |
| `tech-tuesday` | 13 | | `no-section` | 2 |
| `wine-reviews` | 12 | | `administration` | 1 |

A reader who clicks "SJN GRANT" on a real article gets a 404. This is also what generated the `/sjn-grant` traffic in the CMS error metrics — #83 makes those requests free rather than two failed CMS calls, which removes the symptom and leaves the dead link.

## The fix

`getCategoryHref()` resolves a category the way the CMS already models it:

1. the slug, if it is a routable section or subsection;
2. otherwise the category **title** against the taxonomy's `category_aliases` — how an imported label reaches the section that owns it. `Podcasts` belongs to Columns, `Arts & Entertainment` to Entertainment, `Men's Lacrosse` to Sports.
3. Only when neither resolves does the label lose its link.

An unlinked label renders as an `<a>` with no `href`, which is what HTML has for a link that is not currently active. It looks identical to the reader and keeps the markup a single expression.

If the taxonomy cannot be read at all, the old behaviour stands and the slug is linked anyway — a link that might 404 beats dropping every category link on the site for as long as the CMS is unreachable.

## Verification

Against the live Delta CMS:

| Article | Kicker | Related cards |
| --- | --- | --- |
| `international-students-…` (SJN Grant) | `SJN Grant`, `<a>` — unlinked | `/news` linked, 2 unlinked |
| `drexel-sees-wins-and-losses…` (Wrestling) | `Wrestling`, `<a>` — unlinked | `/sports` linked, 2 unlinked |
| `programs-offer-opportunities…` (News) | `News`, `<a href="/news">` | — |

Zero failed CMS calls per page load in all three.

No article in the corpus currently has a primary category that resolves *only* through an alias, so that branch was exercised directly rather than left untested: `Podcasts` → `/columns`, `"  arts & entertainment "` → `/entertainment`, `sjn-grant` → no link, `undefined` → no link. The CMS-unreachable path was exercised the same way and falls back to the raw slug for all of them.

`npm run lint` clean, `astro check` 0 errors / 0 warnings (8 pre-existing hints), build clean.

## Not in scope

`/podcasts` itself is a *legacy inbound* URL — nothing on the live site links it, and no article carries it as a primary category. It was a WordPress category archive folded into Columns at migration, and something still requests it about five times an hour. Fixing that needs a legacy **category** redirect map (`/podcasts` → `/columns`), the section-level counterpart to the existing `LEGACY_ARTICLE_SLUGS`, which only covers `/article/*`. Worth its own card.

Also worth an editorial look rather than a code fix: `wrestling` has 103 articles and no home. Several of these probably deserve to be real subsections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)