### PR TITLE
Redirect the WordPress category archives we folded into a section

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,28 @@
 import type { MiddlewareHandler } from "astro";
 import { LEGACY_ARTICLE_SLUGS } from "./utils/legacySlugs";
+import { LEGACY_SECTION_SLUGS } from "./utils/legacySections";
 
-// The WordPress archive and the CMS disagree on a handful of article slugs, so
-// URLs Google already indexed would 404 after the cutover. A 301 hands the
+// The WordPress archive and the CMS disagree on a handful of URLs, so addresses
+// Google already indexed would 404 after the cutover. A 301 hands the
 // accumulated ranking to the new URL instead of dropping it.
 //
-// This runs ahead of the /article/[slug] route, and only fires on an exact map
-// hit, so every other request costs one object lookup and nothing else.
+// Two maps, because the two cases have nothing to do with each other: renamed
+// article slugs under /article/, and root-level category archives that were
+// folded into a section. Both only fire on an exact hit, so every other request
+// costs one or two object lookups and nothing else.
 export const onRequest: MiddlewareHandler = (context, next) => {
   const { pathname } = context.url;
-  if (!pathname.startsWith("/article/")) return next();
+
+  if (!pathname.startsWith("/article/")) {
+    // A dead category archive. Checked before the catch-all route sees it,
+    // which is also what keeps these off the CMS: an unrouted root path
+    // otherwise reaches [sectionSlug] and asks the taxonomy about it.
+    const section = pathname.slice(1).replace(/\/+$/, "").toLowerCase();
+    const sectionTarget = section ? LEGACY_SECTION_SLUGS[section] : undefined;
+    if (sectionTarget) return context.redirect(sectionTarget, 301);
+
+    return next();
+  }
 
   const slug = pathname.slice("/article/".length).replace(/\/+$/, "");
   // A malformed escape ("%zz") throws rather than returning the input, and a

--- a/src/utils/legacySections.ts
+++ b/src/utils/legacySections.ts
@@ -1,0 +1,27 @@
+// Root-level WordPress category archives that no longer exist, mapped to the
+// page that absorbed them.
+//
+// WordPress gave every category an archive at /<slug>/, so URLs like /podcasts
+// are in Google's index and on paper the newsroom handed out. The migration
+// folded some of those categories into a section instead of giving them a row
+// in site_taxonomy, and the CMS only routes slugs that have one -- so the URL
+// 404s with nothing to say where its content went.
+//
+// This is the section-level counterpart to LEGACY_ARTICLE_SLUGS, which only
+// covers /article/*. Kept in a separate module deliberately: that map is
+// regenerated wholesale after every reseed, and a hand-maintained entry living
+// in it would be silently overwritten.
+//
+// Add an entry only where the destination genuinely holds the content. The CMS
+// records this relationship itself as a `category_aliases` entry on the owning
+// section -- "Podcasts" is listed on Columns -- so that is the source to check
+// before adding a row here.
+//
+// If a slug here is ever given a real taxonomy row, remove it from this map:
+// the redirect runs ahead of routing and would shadow the new page.
+export const LEGACY_SECTION_SLUGS: Record<string, string> = {
+  // Columns carries "Podcasts" in its category_aliases. 784 requests over the
+  // ten days of retained logs, and nothing on the site links it -- this is
+  // entirely inbound from the WordPress era.
+  podcasts: "/columns",
+};


### PR DESCRIPTION
WordPress gave every category an archive at `/<slug>/`, so `/podcasts` is in Google's index and on paper the newsroom handed out. The migration folded that category into Columns — the CMS records it as a `category_aliases` entry on the Columns row — without giving it a taxonomy row of its own, and the CMS only routes slugs that have one. The URL 404s with nothing to say where its content went.

**784 requests over the ten days of retained logs, and nothing on the site links it** — I checked the homepage, `/columns`, `/about`, `/one-hundred`, `/entertainment`, `/comics-puzzles` and a full article page including the footer. It is entirely inbound from the WordPress era.

A 301 to `/columns` hands the accumulated ranking to the page that actually holds the content, the same reasoning as the existing article slug map.

## Shape

`LEGACY_SECTION_SLUGS` lives in its own module rather than in `legacySlugs.ts`, deliberately: that map is regenerated wholesale after every reseed, and a hand-maintained entry living in it would be silently overwritten.

The middleware checks it ahead of the catch-all route, so these cost **zero** CMS requests rather than a taxonomy lookup and a 404 render.

## Verification

| Request | Result | CMS calls |
| --- | --- | --- |
| `/podcasts` | 301 → `/columns` | 0 |
| `/podcasts/` | 301 → `/columns` | 0 |
| `/PODCASTS` | 301 → `/columns` | 0 |
| `/columns` | 200 | 5 |
| `/news` | 200 | 5 |
| `/nonexistent-thing` | 404 | 1 |
| `/article/america-the-beautiful` | 301 → `/article/america-the-beautiful-9663` | — |

The last row matters: the article-slug redirects still work, since this restructures the middleware's early return.

`npm run lint` clean, `astro check` 0 errors / 0 warnings (8 pre-existing hints), build clean.

## Why only podcasts

The other non-routable category slugs in the error metrics — `sjn-grant` (804), `administration` (412), and nine smaller ones — are reached from links the **article pages themselves render**, not from inbound URLs. Those links are removed in #84. Adding redirects for them would be guessing at a destination the CMS does not record, whereas Columns owning "Podcasts" is written down in the taxonomy.

Worth re-measuring after #84 ships: whatever traffic survives for those slugs is genuinely inbound and has earned an entry here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)