### PR TITLE
Stop routing every two-segment path into an article lookup

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,8 +10,54 @@ import { LEGACY_SECTION_SLUGS } from "./utils/legacySections";
 // article slugs under /article/, and root-level category archives that were
 // folded into a section. Both only fire on an exact hit, so every other request
 // costs one or two object lookups and nothing else.
+// WordPress published a feed under every archive and every post -- /news/feed,
+// /tag/phillies/feed, /<post-slug>/feed, plus the /atom and .xml spellings of
+// each. Those are subscriptions: a reader's aggregator polls the URL forever and
+// silently drops the paper when it starts 404ing. This site has one feed, so
+// they all land there rather than nowhere. 131 requests over the ten days of
+// retained logs, all of which previously 301'd to /article/feed and 404'd.
+const FEED_SEGMENTS = new Set([
+  "feed",
+  "atom",
+  "rss",
+  "feed.xml",
+  "atom.xml",
+  "rss.xml",
+  "index.xml",
+]);
+
+// Asset requests for a site that no longer serves them: sw.js and
+// workbox-<hash>.js from the WordPress-era service worker still installed in
+// returning browsers, and the crawler-driven sitemap and manifest spellings this
+// site does not use. Answered here so they stop at the edge -- [sectionSlug]
+// otherwise asks the CMS about each one twice, once as a section and once as a
+// subsection, which is where the 86 sw.js lookups in the logs came from.
+//
+// Deliberately an explicit list and not a general "has a file extension" test.
+// robots.txt, ads.txt, favicon.ico and the rest of public/ are real files, and
+// /sitemap-index.xml and /sitemap-<year>.xml are real routes; a blanket
+// extension rule would answer 404 for all of them if the adapter ever let a
+// static path reach middleware.
+const DEAD_ASSETS = new Set([
+  "/sw.js",
+  "/sitemap.xml",
+  "/sitemap_index.xml",
+  "/manifest.webmanifest",
+]);
+const DEAD_WORKBOX = /^\/workbox-[0-9a-f]+\.js$/i;
+
 export const onRequest: MiddlewareHandler = (context, next) => {
   const { pathname } = context.url;
+
+  // /feed is itself a real route and must not be folded into itself.
+  const last = pathname.split("/").filter(Boolean).at(-1)?.toLowerCase();
+  if (last && FEED_SEGMENTS.has(last) && pathname !== "/feed") {
+    return context.redirect("/feed", 301);
+  }
+
+  if (DEAD_ASSETS.has(pathname) || DEAD_WORKBOX.test(pathname)) {
+    return new Response(null, { status: 404 });
+  }
 
   if (!pathname.startsWith("/article/")) {
     // A dead category archive. Checked before the catch-all route sees it,

--- a/src/pages/[sections]/[article].astro
+++ b/src/pages/[sections]/[article].astro
@@ -11,6 +11,7 @@ import Social from '../../components/Social.astro';
 import Poll from '../../components/Polls.astro';
 import { getArticle, getArticleComments } from '../../utils/db';
 import { getCategoryHref } from "../../utils/taxonomyStore";
+import { LEGACY_ARTICLE_SLUGS } from '../../utils/legacySlugs';
 import { normalizeText } from "../../utils/data";
 import { expandShortcodes } from "../../utils/shortcodes";
 import { normalizeArticleHtml } from "../../utils/articleHtml";
@@ -37,8 +38,36 @@ if (host === 'thetriangle.org') {
     301,
   );
 }
-if(sections !== "article"){
-return Astro.redirect('/article/'+article, 301);
+// WordPress served articles at /<category>/<slug>, so those two-segment URLs are
+// still indexed and still linked, and they redirect to this site's /article/<slug>.
+//
+// That redirect used to fire on the *shape* of the path alone, without asking
+// whether the second segment named an article at all. Every other two-segment
+// WordPress URL matches the same shape -- /tag/<term> archives, /page/<n>
+// pagination, /about/us -- so each one 301'd to an /article/ URL that could only
+// 404, turning one dead URL into two requests plus a redirect hop that hid the
+// original path from the CMS logs. 633 such lookups over the retained window
+// across 256 distinct slugs, nearly all of them tag archives.
+//
+// So resolve first and redirect only on a hit. The extra lookup lands only on the
+// legacy path and is a cheap one: the CMS marks article detail cacheable for a
+// minute and this fetch is force-cache, so the redirected request reads it warm.
+if (sections !== "article") {
+  // A renamed slug resolves through the map rather than the CMS -- the middleware
+  // only rewrites paths already under /article/, so without this a legacy slug
+  // arriving under its old category would 404 here instead of reaching its
+  // replacement.
+  const renamed = article ? LEGACY_ARTICLE_SLUGS[article] : undefined;
+  if (renamed) {
+    return Astro.redirect('/article/' + renamed, 301);
+  }
+
+  const legacyPost = article ? await getArticle(article) : undefined;
+  if (!legacyPost) {
+    return Astro.rewrite('/404');
+  }
+
+  return Astro.redirect('/article/' + article, 301);
 }
 
 const post = article ? await getArticle(article) : undefined;


### PR DESCRIPTION
Reported as "errors on /feed". The cause was not the feed route.

## What was happening

[`[sections]/[article].astro`](src/pages/[sections]/[article].astro) redirected **any** two-segment path to `/article/<second-segment>` based purely on the shape of the URL, without checking whether such an article existed:

```
/news/feed              301 → /article/feed              → 404
/tag/governor-tom-wolf  301 → /article/governor-tom-wolf → 404
/about/us               301 → /article/us                → 404
```

The redirect hop erased the original path, so the CMS logs only ever showed the second request — a lookup for an article called `feed`, with nothing to say where it came from.

Tallying the backend logs over the retained window: **633 bogus article lookups across 256 distinct slugs**. The distribution identifies the sources exactly — `feed` (93) and `atom` (38) are WordPress's per-archive feeds, and the long tail (`phillies`, `tuukka-rask`, `stem`, `police`, …) is `/tag/<term>` archives.

Separately, the single-segment catch-all asks the CMS about every unrouted root path *twice* (once as a section, once as a subsection). `sw.js` — the WordPress-era service worker still installed in returning browsers — accounted for 86 lookups on its own.

## Changes

**Resolve before redirecting.** The `/<category>/<slug>` redirect now fires only when the article actually resolves. The extra lookup falls only on the legacy path and is cheap: article detail is cacheable for a minute and the fetch is `force-cache`, so the redirected request reads it back warm.

The renamed-slug map is consulted first. The middleware only rewrites paths already under `/article/`, so resolving against the CMS alone would have 404'd a legacy slug arriving under its old category — a case that previously worked, and the one real regression risk in this change.

**Feed URLs land on the feed.** WordPress published a feed under every archive and post, in the `/feed` and `/atom` spellings plus their `.xml` forms. Those are live subscriptions — an aggregator polls one forever and silently drops the paper when it starts failing — so they now 301 to this site's one feed rather than 404.

**Dead asset paths stop at the edge.** `sw.js`, `workbox-<hash>.js`, and the sitemap/manifest spellings this site does not use. Kept as an explicit list rather than a general "has a file extension" test: `robots.txt`, `ads.txt` and `favicon.ico` are real files in `public/`, and `/sitemap-index.xml` and `/sitemap-<year>.xml` are real routes — a blanket rule would 404 all of them.

## Verification

`astro check`: 0 errors. Dev server run against the live CMS over a tunnel to the Delta backend.

| Path | Before | After |
|---|---|---|
| `/news/feed`, `/rss.xml`, `/atom` | 301 → 404 | 301 → `/feed` (20 items) |
| `/tag/roasted`, `/about/us`, `/page/12` | 301 → 404 | 404 |
| `/sw.js`, `/sitemap.xml` | 2 CMS calls → 404 | 404, no CMS call |
| `/feed`, `/robots.txt`, `/sitemap-index.xml` | 200 | 200 |
| `/news/<real-slug>` | 301 → 200 | 301 → 200 |
| `/news/america-the-beautiful` (renamed) | 301 → 301 → 200 | 301 → `america-the-beautiful-9663` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)