### PR TITLE
Resolve author URLs the import filed under a different slug

### DIFF
--- a/src/pages/author/[author].astro
+++ b/src/pages/author/[author].astro
@@ -11,6 +11,7 @@ import Poll from '../../components/Polls.astro';
 import '../../styles/global.css';
 import { getAuthorArticles } from '../../utils/db';
 import { getSlugKind } from '../../utils/taxonomyStore';
+import { resolveAuthorSlug } from '../../utils/authorIndex';
 import Scroll from "../../components/Sections/Scroll.astro";
 
 const pageNum = 1;
@@ -30,6 +31,20 @@ if (!authorData) {
   const kind = author ? await getSlugKind(author) : 'unknown';
   if (kind === 'section' || kind === 'subsection') {
     return Astro.redirect('/' + author, 301);
+  }
+
+  // The rest are real people whose slug the import got wrong. It builds them
+  // from the WordPress login, and the logins do not agree with the names the
+  // site links by -- rkeating, by-nayab-iqbal, sanjana-bandi-2 and
+  // stefan-kusmirek-dev-thetriangle-org are four different shapes of the same
+  // defect. Matching on the display name is what they have in common.
+  //
+  // The ETL fix for this only lands on the next reseed, and these are live 404s
+  // now, so the recovery lives here. It runs only after the lookup misses, so a
+  // real author's page never pays for it.
+  const resolved = author ? await resolveAuthorSlug(author) : null;
+  if (resolved) {
+    return Astro.redirect('/author/' + resolved, 301);
   }
 
   return Astro.rewrite('/404');

--- a/src/utils/authorIndex.ts
+++ b/src/utils/authorIndex.ts
@@ -1,0 +1,151 @@
+// Server-side cache of author display names, used to answer one question the
+// site cannot answer on its own: /author/<slug> named a real person, so which
+// slug does the CMS actually hold them under?
+//
+// The import derives an author's slug from the WordPress login, and the logins
+// are not consistent with the names the site links by. Four shapes are live in
+// production today:
+//
+//   ryan-keating       -> rkeating                             (abbreviated login)
+//   nayab-iqbal        -> by-nayab-iqbal                        (byline text as login)
+//   sanjana-bandi-2    -> sanjana-bandi                         (WordPress duplicate suffix)
+//   stefan-kusmirek    -> stefan-kusmirek-dev-thetriangle-org   (email as login)
+//
+// No pattern covers all four, and the next import will invent a fifth. Matching
+// on the display name instead is the one thing they have in common: the CMS
+// holds the right name in every case, only the slug is wrong. That also means
+// this keeps working after the ETL fix lands and the slugs change.
+//
+// Like taxonomyStore, this module is shared across requests because the node
+// adapter runs a single long-lived process.
+
+import { getAllAuthors } from './db';
+
+/** Authors change when someone writes their first piece. */
+const CACHE_TTL_MS = 10 * 60 * 1000;
+/** After a failure with nothing to serve, retry sooner. */
+const ERROR_BACKOFF_MS = 30 * 1000;
+/** Keep serving a stale index this long if the CMS is down. */
+const STALE_MAX_MS = 60 * 60 * 1000;
+
+/** Canonicalized display name -> the slug the CMS holds that person under. */
+type NameIndex = Map<string, string>;
+
+type CacheEntry = {
+  /** null when the last attempt failed and we have nothing to serve. */
+  index: NameIndex | null;
+  fetchedAt: number;
+};
+
+let cache: CacheEntry | null = null;
+/** Dedupes concurrent misses so a burst of traffic makes one upstream call. */
+let inFlight: Promise<CacheEntry> | null = null;
+
+/** The same transformation the CMS applies when it builds a slug from a name. */
+function canonicalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function indexAuthors(authors: { slug?: string; display_name?: string }[]): NameIndex {
+  const index: NameIndex = new Map();
+
+  for (const author of authors) {
+    if (typeof author?.slug !== 'string' || !author.slug) continue;
+    if (typeof author.display_name !== 'string') continue;
+
+    const key = canonicalize(author.display_name);
+    // The first author to claim a name keeps it. Two people who share a display
+    // name are indistinguishable from this URL, and picking the earlier record
+    // at least makes the choice stable between restarts.
+    if (key && !index.has(key)) index.set(key, author.slug);
+  }
+
+  return index;
+}
+
+async function fetchIndex(): Promise<NameIndex | null> {
+  try {
+    const authors = await getAllAuthors();
+    if (!authors) {
+      console.error('AuthorIndex: CMS did not return a usable /v1/authors payload.');
+      return null;
+    }
+
+    const index = indexAuthors(authors);
+    if (index.size === 0) {
+      // A CMS with no authors at all is a broken CMS, not a paper nobody wrote
+      // for. Treat it as a failure rather than caching an empty index that
+      // would answer "no such person" for everyone.
+      console.error('AuthorIndex: /v1/authors held no usable authors.');
+      return null;
+    }
+
+    return index;
+  } catch (err) {
+    console.error('AuthorIndex: fetch failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+function isFresh(entry: CacheEntry, now: number): boolean {
+  const ttl = entry.index === null ? ERROR_BACKOFF_MS : CACHE_TTL_MS;
+  return now - entry.fetchedAt < ttl;
+}
+
+async function loadIndex(): Promise<NameIndex | null> {
+  const now = Date.now();
+
+  if (cache && isFresh(cache, now)) {
+    return cache.index;
+  }
+
+  if (!inFlight) {
+    inFlight = fetchIndex()
+      .then((index) => {
+        // A failed refresh keeps the last good index while it is recent enough.
+        if (index === null && cache?.index && now - cache.fetchedAt < STALE_MAX_MS) {
+          return { index: cache.index, fetchedAt: now };
+        }
+        return { index, fetchedAt: now };
+      })
+      .then((entry) => {
+        cache = entry;
+        return entry;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+
+  const entry = await inFlight;
+  return entry.index;
+}
+
+/**
+ * The slug the CMS holds for the person a URL names, or null.
+ *
+ * Call this only after the author lookup has already missed -- it is the
+ * recovery path, and it costs several CMS round trips the first time.
+ *
+ * Also tries the name with a trailing WordPress duplicate suffix removed, since
+ * /author/sanjana-bandi-2 names a person the CMS records once, without it.
+ * Limited to one or two digits: real CMS slugs carry a numeric id suffix to
+ * break collisions (erik-heyman-meltzer-870), and a broader rule would be one
+ * bad import away from resolving a URL to a different person.
+ *
+ * Never throws, and returns null when the index could not be read, so a CMS
+ * blip leaves the 404 in place rather than inventing a redirect.
+ */
+export async function resolveAuthorSlug(requested: string): Promise<string | null> {
+  if (!requested) return null;
+
+  const index = await loadIndex();
+  if (!index) return null;
+
+  for (const key of [requested, requested.replace(/-\d{1,2}$/, '')]) {
+    const slug = index.get(canonicalize(key));
+    if (slug && slug !== requested) return slug;
+  }
+
+  return null;
+}

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -117,6 +117,43 @@ export async function getSectionArticles(section, page) {
  * genuinely empty taxonomy.
  * @returns {Promise<TaxonomyItem[]|undefined>}
  */
+/**
+ * Every author, paged out of the CMS.
+ *
+ * Only used to answer "which slug holds the person this URL names", so it is
+ * worth the several round trips it costs -- 875 authors at 200 a page today.
+ * Go through authorIndex rather than calling this directly: it has no cache of
+ * its own, and this must never sit on the path of a URL that already resolves.
+ *
+ * Returns undefined if any page fails, so a caller can tell an unreachable CMS
+ * from a genuinely empty list. A partial index is worse than none here: a page
+ * that failed to load looks exactly like an author who does not exist.
+ * @returns {Promise<{slug: string, display_name: string}[]|undefined>}
+ */
+export async function getAllAuthors() {
+  const limit = 200;
+  const authors = [];
+
+  for (let offset = 0; ; offset += limit) {
+    const url = `${normalizedCmsBaseUrl}/authors?limit=${limit}&offset=${offset}`;
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+
+    if (!res.ok) return;
+    const body = await res.json();
+    if (!Array.isArray(body?.authors)) return;
+
+    authors.push(...body.authors);
+    if (!body.pagination?.has_more) return authors;
+
+    // The CMS decides when the pages run out; this only stops a pagination bug
+    // from spinning here forever.
+    if (authors.length > 20000) return authors;
+  }
+}
+
 export async function getTaxonomy() {
   const url = normalizedCmsBaseUrl + '/taxonomy';
 


### PR DESCRIPTION
The second half of the author work. #88 merged only its first commit — the category-archive redirects — so this carries the part that recovers real people, rebased onto main.

## The defect

The import derives an author's slug from the WordPress login, and the logins don't agree with the names the site links by. Four distinct shapes are live in production:

| URL that is linked | slug the CMS holds | why |
|---|---|---|
| `ryan-keating` | `rkeating` | abbreviated login |
| `nayab-iqbal` | `by-nayab-iqbal` | byline text used as the login |
| `sanjana-bandi-2` | `sanjana-bandi` | WordPress duplicate-account suffix |
| `stefan-kusmirek` | `stefan-kusmirek-dev-thetriangle-org` | email used as the login |

**Ryan Keating has 59 articles and his author page was unreachable from every URL that names him.** Seven authors are affected in total.

## Why display-name matching

I started with pattern rules — strip a `by-` prefix, strip a `-2` suffix — and they were wrong. `rkeating` and the email-derived slug fit no prefix rule, and the next import will invent a fifth shape.

The display name is the one thing all four have in common: the CMS holds the *right name* in every case, only the slug is wrong. Matching on it covers all four without enumerating them, and it keeps working after the ETL fix (DrexelTriangle/wordpress-etl#63) changes the slugs.

`src/utils/authorIndex.ts` builds the index from a paged `/v1/authors` sweep and caches it in process, on the `taxonomyStore` pattern already in the repo: same TTL-plus-stale-fallback, same single-flight dedupe, same refusal to cache an empty result — an index with no authors would answer "no such person" for everyone. 875 authors, ~114 KB.

`getAllAuthors` returns undefined if *any* page fails rather than a partial list, because a page that failed to load is indistinguishable from an author who does not exist.

## Cost and safety

It runs **only after the author lookup has already missed**, so a page that resolves pays nothing. It returns null when the CMS can't be read, leaving the 404 in place rather than inventing a 301 during a blip that then caches.

The duplicate-suffix strip is limited to one or two digits: real CMS slugs carry a numeric id suffix to break collisions (`erik-heyman-meltzer-870`), and a broader rule would be one bad import away from resolving a URL to a different person.

## Verification

`astro check`: 0 errors. Dev server against the live CMS, on this branch rebased onto current main:

```
/author/ryan-keating         301 → /author/rkeating
/author/nayab-iqbal          301 → /author/by-nayab-iqbal
/author/sanjana-bandi-2      301 → /author/sanjana-bandi
/author/stefan-kusmirek      301 → /author/stefan-kusmirek-dev-thetriangle-org

/author/rkeating                 200   (real slug, untouched)
/author/erik-heyman-meltzer-870  200   (real numeric-suffix slug, not stripped)
/author/crossword                301 → /crossword   (#88 behaviour, still intact)
/author/news                     301 → /news
/author/beeboop                  404   (genuinely unknown)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)