### PR TITLE
Stop giving classifieds a section's billing on an empty page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -56,7 +56,10 @@
     <a class="hover:underline" href="/sports"> Sports </a>
     <a class="hover:underline" href="/entertainment"> Entertainment </a>
     <a class="hover:underline" href="/comics-puzzles"> Comics </a>
-    <a class="hover:underline" href="/classifieds"> Classifieds </a>
+    <!-- Classifieds is a service, not a section, and this row is sections. It
+         keeps its place in the utility nav above and in the side menu, which is
+         where the side menu has always filed it -- with About and Contact
+         rather than with News and Sports. -->
     <!-- Graduation is out of season; uncomment when the issue comes back around. -->
     <!-- <a class="relative hover-underline" href="/graduation"> Graduation </a> -->
   </nav>

--- a/src/pages/classifieds.astro
+++ b/src/pages/classifieds.astro
@@ -43,7 +43,11 @@ const classifieds = await getClassifieds();
         class="grid grid-cols-[1fr] sm:grid-cols-[8fr_4fr] mt-2 xl:max-w-[1200px] lg:max-w-[900px] max-w-[90%] mx-[auto] mb-[8px] divide-x divide-triangleBlue pt-[5px]"
     >
         <div id="main-left" class="main-side">
-            {classifieds.map((classified: ClassifiedPost) => (
+            {classifieds.length === 0 ? (
+            <p class="font-libre text-[16px] text-gray-600 py-[24px]">
+                No classifieds are running right now. Yours could be the first &mdash; submissions are free, and they go up once an editor approves them.
+            </p>
+            ) : classifieds.map((classified: ClassifiedPost) => (
             <Classified contact={classified.name} email={classified.email} label={classified.label} message={classified.message}/>
         ))}
         </div>


### PR DESCRIPTION
## What

Two small changes to `/classifieds`:

1. Drops the **Classifieds** entry from the section nav (the second header row).
2. Adds an empty state to the classifieds listing column.

## Why

**The nav entry was a duplicate in the wrong row.** The section nav is sections — News, Opinion, Sports, Entertainment, Comics — and Classifieds was the only entry there that isn't one, while also sitting in the utility nav directly above it. `SideMenu.astro` has always filed it with About and Contact rather than with News and Sports; this makes the section nav agree.

**The page behind it is empty and looked broken.** The `classifieds` table has never held a row (0 across all statuses on the live DB), and the listing column mapped over the array with no fallback — so the page rendered as a headline, a blurb, and a blank half-width column next to the form. "Nothing running yet" and "this page is broken" looked identical, which is the worse outcome for the one page whose job is to convince somebody to post.

## What is deliberately *not* changed

The intake. The form works, and submissions are the only thing that can ever fill this page, so Classifieds keeps its place in the utility nav and in the side menu. This drops one entry point, not the feature.

The empty-state copy says listings "go up once an editor approves them", which matches the actual workflow — `classifieds.status` defaults to `pending` and the public listing serves approved-and-unexpired only.

## Testing

`eslint` clean, `astro check` 0 errors / 0 warnings (8 pre-existing hints). Rendered `/classifieds` and `/news` locally against the live CMS API over an SSH tunnel, so the empty state is the real empty response rather than a fixture — screenshots confirm the section nav reads News · Opinion · Sports · Entertainment · Comics with Classifieds still present in the utility nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)