### PR TITLE
Let /podcasts be the Podcasts page it now has

### DIFF
--- a/src/utils/legacySections.ts
+++ b/src/utils/legacySections.ts
@@ -12,16 +12,18 @@
 // regenerated wholesale after every reseed, and a hand-maintained entry living
 // in it would be silently overwritten.
 //
-// Add an entry only where the destination genuinely holds the content. The CMS
-// records this relationship itself as a `category_aliases` entry on the owning
-// section -- "Podcasts" is listed on Columns -- so that is the source to check
-// before adding a row here.
+// Add an entry only where the destination genuinely holds the content, and only
+// where the slug has no taxonomy row of its own. A row is always the better
+// answer: it gives the category its own page instead of pointing at a section
+// that merely contains it.
 //
-// If a slug here is ever given a real taxonomy row, remove it from this map:
-// the redirect runs ahead of routing and would shadow the new page.
-export const LEGACY_SECTION_SLUGS: Record<string, string> = {
-  // Columns carries "Podcasts" in its category_aliases. 784 requests over the
-  // ten days of retained logs, and nothing on the site links it -- this is
-  // entirely inbound from the WordPress era.
-  podcasts: "/columns",
-};
+// If a slug here is ever given a real taxonomy row, remove it from this map.
+// The redirect runs ahead of routing, so it shadows the new page completely --
+// which is what happened to /podcasts. The CMS gave Podcasts a subsection row
+// with 75 articles, and this map went on sending every request for it to
+// /columns -- 784 of them in the ten days of logs that were retained when this
+// entry was added, none of them from a link on the site.
+//
+// Empty is the healthy state. Every WordPress sub-category the migration left
+// behind now has a row.
+export const LEGACY_SECTION_SLUGS: Record<string, string> = {};


### PR DESCRIPTION
## The bug

`podcasts` reports 75 articles on the CMS sections screen, and `/podcasts` on the site serves none of them — it 301s to `/columns`.

## Cause

`LEGACY_SECTION_SLUGS` maps dead WordPress category archives to whichever section absorbed them, and it held exactly one entry: `podcasts: "/columns"`, added when Podcasts existed only as a `category_aliases` entry on Columns.

DrexelTriangle/triangle-cms#215 gave Podcasts a subsection row with a page of its own. The redirect runs in middleware, ahead of routing, so it shadows that page completely — every request for `/podcasts` still lands on `/columns`, and the article count in the CMS was the only visible sign the page existed.

The module's own comment predicted this:

> If a slug here is ever given a real taxonomy row, remove it from this map: the redirect runs ahead of routing and would shadow the new page.

So this is that removal.

## Scope

I checked all 48 seeded slugs against production before assuming this was isolated. `/podcasts` was the only one shadowed:

```
podcasts        301 -> /columns
wrestling       200   (Wrestling - The Triangle, 34 articles)
editorial       200   (Editorial - The Triangle, 34 articles)
mens-lacrosse   200   (Men's Lacrosse - The Triangle, 34 articles)
tennis, crew, style, tv, theater, features, commentary,
word-search, triangle-talks, swimming-diving, administration … all 200
```

## Why keep an empty map

The mechanism is still right for the next WordPress archive that needs it, and the file carries the reasoning for when to add an entry versus when to create a taxonomy row instead. Empty is now the healthy state — every sub-category the migration left behind has a row.

## Testing

`eslint` clean, `astro check` 0 errors / 0 warnings. Ran the site locally against the production CMS API over an SSH tunnel: `/podcasts` returns 200, titles as "Podcasts - The Triangle", and renders 34 article links instead of redirecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)