### PR TITLE
Play the podcasts and videos instead of printing their shortcodes

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -200,6 +200,46 @@ body {
 }
 
 /*
+ * Expanded WordPress media shortcodes: a YouTube video and a SoundCloud player.
+ *
+ * The sizing lives here rather than in the markup expandShortcodes emits,
+ * because the article page strips width and height out of every inline style it
+ * renders. That pass exists to unpick the dimensions WordPress baked into its
+ * images and it cannot tell an embed's layout from an image's, so an iframe
+ * that sizes itself inline loses both and falls back to the HTML default of
+ * 300x150 -- which is exactly what these did before the class.
+ *
+ * Video gets a 16:9 box rather than the shortcode's own 560x315: that is a
+ * fixed-width column from 2013 and it does not survive a phone.
+ *
+ * Scoped to these two classes, never to .article-embed itself: that class is
+ * what opts a wrapper OUT of the 700px prose column, and the puzzle embed needs
+ * every pixel it can get.
+ */
+#article .article-embed-video,
+#article .article-embed-audio {
+  @apply my-[16px] mx-[auto] max-w-[700px];
+}
+
+#article .article-embed-video {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+#article .article-embed-video iframe,
+#article .article-embed-audio iframe {
+  border: 0;
+}
+
+#article .article-embed-video iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/*
  * Trix's heading button emits <h1> and its quote button a bare <blockquote>.
  * Neither had any rule here, so Tailwind's preflight flattened them into
  * body text. Sized down from the article title, which is the page's real h1.

--- a/src/utils/shortcodes.ts
+++ b/src/utils/shortcodes.ts
@@ -66,15 +66,93 @@ function puzzlemeEmbed(raw: string): string {
 }
 
 /**
+ * The player URL WordPress's SoundCloud shortcode built, rebuilt here.
+ *
+ * The shortcode carries the track as `url` and the player options as a `params`
+ * query string of its own: `params="color=#000000&auto_play=false&..."`. Both
+ * go into w.soundcloud.com/player/ as query parameters, with the track URL
+ * percent-encoded inside it -- which matters, because these are private tracks
+ * whose URL carries a `?secret_token=`, and losing it makes the player 404.
+ *
+ * Entity decoding first: a body written in the CMS editor stores the `&` in
+ * params as `&amp;`, and parsing that literally yields one option named
+ * "amp;auto_play". On a WordPress-era body it is a no-op.
+ */
+function soundcloudEmbed(raw: string): string {
+  const attributes = parseAttributes(raw);
+  const track = he.decode(attributes.url ?? "");
+
+  // No track, nothing to play. Leave the shortcode visible rather than emit an
+  // empty player, the same way puzzlemeEmbed does.
+  if (!track) return `[soundcloud ${raw}]`;
+
+  const player = new URL("https://w.soundcloud.com/player/");
+  player.searchParams.set("url", track);
+  for (const [option, value] of new URLSearchParams(
+    he.decode(attributes.params ?? ""),
+  )) {
+    player.searchParams.set(option, value);
+  }
+
+  // The shortcode's own height, which is 300 on every article in the corpus.
+  const height = /^\d+$/.test(attributes.height ?? "") ? attributes.height : "300";
+
+  // Sized by attributes and a class rather than an inline style: the article
+  // page strips width and height declarations out of every inline style it
+  // renders, to unpick the dimensions WordPress baked into its images. An embed
+  // that sizes itself inline gets silently flattened by that pass.
+  return `
+        <div class="article-embed article-embed-audio">
+            <iframe src="${escapeAttribute(player.toString())}" width="100%" height="${height}" loading="lazy" scrolling="no" allow="autoplay" title="SoundCloud player"></iframe>
+        </div>`;
+}
+
+/**
+ * WordPress's YouTube shortcode takes a bare watch URL rather than attributes:
+ * `[youtube https://www.youtube.com/watch?v=ID]`, sometimes with `&w=560&h=315`
+ * appended. Every one of the 97 articles carrying it uses that shape.
+ *
+ * The size hints are dropped on purpose. They encode a 2013 fixed-width column;
+ * the embed is rendered 16:9 and fluid instead, so it works on a phone.
+ */
+function youtubeEmbed(rawUrl: string): string {
+  const trimmed = he.decode(rawUrl.trim());
+  let id = "";
+  try {
+    id = new URL(trimmed).searchParams.get("v") ?? "";
+  } catch {
+    /* not a URL we can read; fall through to leaving the shortcode alone */
+  }
+
+  // Ids are [A-Za-z0-9_-]; anything else came out of a malformed shortcode and
+  // would build a src pointing at nothing.
+  if (!/^[\w-]+$/.test(id)) return `[youtube ${rawUrl}]`;
+
+  // The 16:9 box is a class, not an inline style, for the reason given in
+  // soundcloudEmbed: inline width and height do not survive the article page's
+  // dimension stripping, and an iframe that loses them falls back to the HTML
+  // default of 300x150.
+  return `
+        <div class="article-embed article-embed-video">
+            <iframe src="https://www.youtube.com/embed/${escapeAttribute(id)}" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen title="YouTube video"></iframe>
+        </div>`;
+}
+
+/**
  * Expand the shortcodes we support. Anything unrecognised is left untouched,
  * so an unknown shortcode still shows up as text rather than vanishing.
  */
 export function expandShortcodes(content: string): string {
   if (!content || !content.includes("[")) return content;
 
-  return content.replace(/\[puzzleme\s+([^\]]*)\]/gi, (_, raw) =>
-    puzzlemeEmbed(raw),
-  );
+  return content
+    .replace(/\[puzzleme\s+([^\]]*)\]/gi, (_, raw) => puzzlemeEmbed(raw))
+    // Self-closing in practice ("... /]"), so the trailing slash is consumed
+    // here rather than left to land inside the attribute string.
+    .replace(/\[soundcloud\s+([^\]]*?)\s*\/?\]/gi, (_, raw) =>
+      soundcloudEmbed(raw),
+    )
+    .replace(/\[youtube\s+([^\]]+?)\s*\/?\]/gi, (_, raw) => youtubeEmbed(raw));
 }
 
 /**


### PR DESCRIPTION
## The bug

Podcast articles end with a wall of raw shortcode where the player belongs:

```
[soundcloud url="https://api.soundcloud.com/tracks/719072971?secret_token=s-KKVwV" params="color=#000000&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true" width="100%" height="300" iframe="true" /]
```

Article bodies still carry unexpanded WordPress shortcodes, and `expandShortcodes` only knew `[puzzleme]`. Everything else reaches the page as literal text.

## Scope

Counted across published articles before fixing:

| shortcode | articles | status |
|---|---|---|
| `[youtube]` | 97 | fixed here |
| `[puzzleme]` | 60 | already expanded |
| `[soundcloud]` | 44 | fixed here |
| `[gallery]` | 17 | left alone — needs the media library, not a URL rewrite |

**YouTube was not in the report** and is the larger half. It's the same bug in the same function, so it's fixed in the same pass. `[gallery]` is genuinely different work and is left for later.

## How

Both expanders follow `puzzlemeEmbed`: parse attributes, rebuild the markup WordPress emitted, and leave the shortcode visible when it carries nothing usable rather than emitting an empty player. Two details that bite:

- The SoundCloud track URL carries a `?secret_token=` and has to be percent-encoded **whole** inside the player URL, or the track 404s even when it exists.
- Its `params` are entity-decoded first: a body re-saved in the CMS editor stores `&amp;`, and parsing that literally yields an option named `amp;auto_play`.

Sizing lives in `global.css`, not inline. The article page strips `width`/`height` out of every inline style it renders — that pass unpicks the dimensions WordPress baked into its images, and it can't tell an embed's layout from an image's. An iframe that sizes itself inline lost both and fell back to the HTML default of 300x150; I hit this and moved to classes. The rules are scoped to the two new classes and never to `.article-embed`, which is what keeps the puzzle embed out of the 700px prose column.

Video is 16:9 and fluid rather than the shortcode's 560x315, which is a fixed-width column from 2013.

## Heads-up: 31 of the 43 SoundCloud tracks are gone

I checked every distinct track against SoundCloud's oEmbed endpoint. **12 are live and 31 return 404**, with or without their secret token, while a control public track returns 200 — so those recordings are gone from SoundCloud's side, not mis-linked here. The article in the report is one of the dead ones; its player renders SoundCloud's own "Oops, we couldn't find that track."

That's still a better failure than the shortcode blob, and it self-heals if the recordings are ever restored — but restoring them is a newsroom job, not a code one.

## Testing

`eslint` clean, `astro check` 0 errors / 0 warnings, `npm run build` passes. Rendered against the production CMS over an SSH tunnel:

- `/article/more-interaction` — live track plays: "Mark and Jair Explain Sports / More Interaction", artwork, waveform, 37:00.
- `/article/a-yuengling-in-the-pew` — dead track shows SoundCloud's not-found panel.
- `/article/triangles-fave-movies-of-2019` — 25 videos, real thumbnails, 16:9 at 700x394.
- `/article/what-s-on-tea-v` — puzzle wrapper still 795px, unsqueezed. No regression.

Also exercised the parser directly on the real shortcode shapes, including `&amp;`-encoded params, `&w=560&h=315` suffixes, a bare `[soundcloud]`, a malformed URL, and `[sic]` in prose — the last three are left untouched, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)