### PR TITLE
Link a subsection's own children in the nav strip

### DIFF
--- a/src/pages/[sectionSlug].astro
+++ b/src/pages/[sectionSlug].astro
@@ -57,9 +57,12 @@ const sectionName = normalizeText(
 
 let hasMore = posts.pagination.has_more;
 
-// The nav strip lists a section's subsections; a subsection page has none of
-// its own to show.
-const subsectionLinks: Subsection[] = isSubsectionPage ? [] : (posts.subsections ?? []);
+// The nav strip lists whatever hangs directly under this page. A subsection can
+// have children of its own now -- /food links Beer Reviews, Wine Reviews and
+// Restaurant Reviews -- so both kinds of page read the same field. It is absent
+// or empty for the leaf subsections, which is most of them, and the strip then
+// renders as nothing exactly as it did before.
+const subsectionLinks: Subsection[] = posts.subsections ?? [];
 ---
 
 <BaseLayout title={sectionName + " - The Triangle"}>


### PR DESCRIPTION
The CMS taxonomy is three levels now: A&E holds Food, and Food holds Beer Reviews, Wine Reviews, Restaurant Reviews and Cooking.

A subsection page hardcoded an empty strip, on the premise that a subsection had no children to show. So `/food` would have listed its articles with no way to reach the four categories beneath it.

Both kinds of page now read the same `subsections` field, which the CMS sets on subsection responses too. It is absent or empty for the leaf subsections — still most of them — and the strip then renders as nothing, exactly as before.

Depends on DrexelTriangle/triangle-cms#216, which is what populates the field. Until that ships this is a no-op: the field is simply absent and `?? []` covers it.

`astro check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)